### PR TITLE
Add logging for fleet maintenance plan signals

### DIFF
--- a/fleet/signals.py
+++ b/fleet/signals.py
@@ -1,8 +1,11 @@
 # fleet/signals.py
+import logging
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from .models import Vehicle
 from workorders.models import MaintenancePlan, MaintenanceManual
+
+logger = logging.getLogger(__name__)
 
 @receiver(post_save, sender=Vehicle)
 def assign_maintenance_plan_on_vehicle_creation(sender, instance, created, **kwargs):
@@ -22,7 +25,11 @@ def assign_maintenance_plan_on_vehicle_creation(sender, instance, created, **kwa
             
             # Creamos el plan "dormido", enlazando el vehículo con el manual
             MaintenancePlan.objects.create(vehicle=instance, manual=manual)
-            print(f"Plan de mantenimiento '{manual.name}' asignado automáticamente a {instance.plate}.")
+            logger.info(
+                "Plan de mantenimiento '%s' asignado automáticamente a %s.",
+                manual.name,
+                instance.plate,
+            )
         except MaintenanceManual.DoesNotExist:
             # No hacemos nada si no hay un manual para ese tipo de combustible
             pass

--- a/project/settings.py
+++ b/project/settings.py
@@ -90,3 +90,21 @@ REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': ['rest_framework.permissions.IsAuthenticated'],
     'DEFAULT_AUTHENTICATION_CLASSES': ['rest_framework_simplejwt.authentication.JWTAuthentication'],
 }
+
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+        },
+    },
+    'loggers': {
+        'fleet.signals': {
+            'handlers': ['console'],
+            'level': 'INFO',
+            'propagate': False,
+        },
+    },
+}


### PR DESCRIPTION
## Summary
- use a module logger in `fleet.signals` instead of `print`
- configure Django logging to capture `fleet.signals` messages

## Testing
- `PYTHONDONTWRITEBYTECODE=1 python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68afc08077f083229ade1c60506dadab