### PR TITLE
Refactor preventive maintenance scheduling

### DIFF
--- a/workorders/admin.py
+++ b/workorders/admin.py
@@ -35,25 +35,16 @@ except Exception:
 if MaintenancePlan:
     @admin.register(MaintenancePlan)
     class MaintenancePlanAdmin(admin.ModelAdmin):
-        # Ajusta columnas según tus campos reales:
+        """Basic admin for maintenance plans using real model fields."""
+
         list_display = (
             "id",
-            "name",                   # nombre del manual/plan
-            "fuel_type",              # GASOLINA / DIESEL (si existe)
-            "vehicle_type",           # opcional: tipo de vehículo (si existe)
-            "interval_km",            # km entre servicios (si existe)
-            "interval_days",          # días entre servicios (si existe)
-            "is_active",              # activo/inactivo (si existe)
+            "vehicle",
+            "manual",
+            "last_service_km",
+            "last_service_date",
+            "is_active",
         )
-        search_fields = ("name",)
-        list_filter = ("fuel_type", "is_active")  # quita/añade según tus campos
-        ordering = ("name",)
-
-        # Para no romper nada, lo dejo editable por defecto.
-        # Si quieres que sea solo lectura, descomenta esto:
-        # def has_change_permission(self, request, obj=None):
-        #     return False
-        # def has_add_permission(self, request):
-        #     return False
-        # def has_delete_permission(self, request, obj=None):
-        #     return False
+        search_fields = ("vehicle__plate",)
+        list_filter = ("is_active",)
+        ordering = ("vehicle__plate",)

--- a/workorders/services.py
+++ b/workorders/services.py
@@ -1,0 +1,30 @@
+"""Service utilities for workorders app."""
+
+from .models import MaintenanceManual, ManualTask
+
+
+def calc_next_due(vehicle, plan):
+    """Calculate next preventive maintenance target in km and description."""
+    manual = plan.manual or MaintenanceManual.objects.filter(fuel_type=vehicle.fuel_type).first()
+    if not manual:
+        return None, None
+
+    tasks = list(ManualTask.objects.filter(manual=manual).order_by("km_interval"))
+    if not tasks:
+        return None, None
+
+    base_km = plan.last_service_km or 0
+    current_km = vehicle.current_odometer_km or 0
+    delta = max(0, current_km - base_km)
+
+    next_task = next((t for t in tasks if t.km_interval >= delta), None)
+    if next_task:
+        next_due_km = base_km + next_task.km_interval
+        desc = next_task.description
+    else:
+        period = tasks[0].km_interval or 10000
+        multiples = (delta // period) + 1
+        next_due_km = base_km + multiples * period
+        desc = f"Ciclo cada {period} km"
+
+    return next_due_km, desc

--- a/workorders/tests.py
+++ b/workorders/tests.py
@@ -2,4 +2,52 @@
 
 from django.test import TestCase
 
-# Create your tests here.
+from fleet.models import Vehicle
+from workorders.models import MaintenanceManual, ManualTask, MaintenancePlan
+from workorders.services import calc_next_due
+
+
+class CalcNextDueTests(TestCase):
+    """Tests for the ``calc_next_due`` service."""
+
+    def setUp(self):
+        self.vehicle = Vehicle.objects.create(
+            plate="ABC123",
+            brand="Brand",
+            model="Model",
+            year=2020,
+            vehicle_type="Camion",
+            fuel_type=Vehicle.FuelType.DIESEL,
+        )
+        self.manual = MaintenanceManual.objects.create(
+            name="Plan Diesel", fuel_type=Vehicle.FuelType.DIESEL
+        )
+        ManualTask.objects.create(
+            manual=self.manual, km_interval=10000, description="Change oil"
+        )
+        ManualTask.objects.create(
+            manual=self.manual, km_interval=20000, description="Change filter"
+        )
+        ManualTask.objects.create(
+            manual=self.manual, km_interval=30000, description="Check belt"
+        )
+
+    def test_selects_next_task(self):
+        plan = MaintenancePlan.objects.create(
+            vehicle=self.vehicle, manual=self.manual, last_service_km=10000
+        )
+        self.vehicle.current_odometer_km = 15000
+        self.vehicle.save()
+        next_km, desc = calc_next_due(self.vehicle, plan)
+        self.assertEqual(next_km, 20000)
+        self.assertEqual(desc, "Change oil")
+
+    def test_cycles_after_last_task(self):
+        plan = MaintenancePlan.objects.create(
+            vehicle=self.vehicle, manual=self.manual, last_service_km=0
+        )
+        self.vehicle.current_odometer_km = 35000
+        self.vehicle.save()
+        next_km, desc = calc_next_due(self.vehicle, plan)
+        self.assertEqual(next_km, 40000)
+        self.assertEqual(desc, "Ciclo cada 10000 km")


### PR DESCRIPTION
## Summary
- extract `calc_next_due` to `workorders/services.py`
- use shared calculation in preventive close signal and periodic check command
- add unit tests for `calc_next_due`

## Testing
- `python manage.py test workorders -v 2`

------
https://chatgpt.com/codex/tasks/task_e_68b5b5489d1883228029e3a8890b93b8