### PR TITLE
refactor: move fuel upload log model

### DIFF
--- a/fleet/fuel_logs.py
+++ b/fleet/fuel_logs.py
@@ -1,0 +1,28 @@
+"""Modelos relacionados con la carga de registros de combustible."""
+
+from django.conf import settings
+from django.db import models
+
+
+class FuelUploadLog(models.Model):
+    """Registro de archivos de tanqueos procesados para evitar reprocesos pesados."""
+
+    original_filename = models.CharField(max_length=255)
+    sha256 = models.CharField(max_length=64, unique=True)
+    size_bytes = models.BigIntegerField()
+    sheet_name = models.CharField(max_length=100, default="TANQUEOS")
+    rows_processed = models.PositiveIntegerField(default=0)
+    vehicles_updated = models.PositiveIntegerField(default=0)
+    processed_at = models.DateTimeField(auto_now_add=True)
+    processed_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL, on_delete=models.SET_NULL, null=True, blank=True
+    )
+
+    class Meta:
+        ordering = ["-processed_at"]
+
+    def __str__(self) -> str:  # pragma: no cover - string representation
+        return (
+            f"{self.original_filename} ({self.rows_processed} filas) "
+            f"@ {self.processed_at:%Y-%m-%d %H:%M}"
+        )

--- a/fleet/models.py
+++ b/fleet/models.py
@@ -61,24 +61,4 @@ class VehicleZoneHistory(models.Model):
         ordering = ['-start_date']
 
 
-from django.conf import settings
-from django.db import models
-
-class FuelUploadLog(models.Model):
-    """Registro de archivos de tanqueos procesados para evitar reprocesos pesados."""
-    original_filename = models.CharField(max_length=255)
-    sha256 = models.CharField(max_length=64, unique=True)
-    size_bytes = models.BigIntegerField()
-    sheet_name = models.CharField(max_length=100, default="TANQUEOS")
-    rows_processed = models.PositiveIntegerField(default=0)
-    vehicles_updated = models.PositiveIntegerField(default=0)
-    processed_at = models.DateTimeField(auto_now_add=True)
-    processed_by = models.ForeignKey(
-        settings.AUTH_USER_MODEL, on_delete=models.SET_NULL, null=True, blank=True
-    )
-
-    class Meta:
-        ordering = ["-processed_at"]
-
-    def __str__(self) -> str:
-        return f"{self.original_filename} ({self.rows_processed} filas) @ {self.processed_at:%Y-%m-%d %H:%M}"
+from .fuel_logs import FuelUploadLog  # noqa: F401  # Import para registrar el modelo


### PR DESCRIPTION
## Summary
- move `FuelUploadLog` model into new `fleet/fuel_logs.py` module
- remove duplicate `models` and `settings` imports from `fleet/models.py`

## Testing
- `python manage.py makemigrations --check --dry-run` (fails: admin.E033 and other admin.E108/E116 in workorders)
- `python manage.py test fleet` (fails: admin.E033 and related admin issues)


------
https://chatgpt.com/codex/tasks/task_e_68b5b54e29788322aaeba08a18d88a98