### PR TITLE
Add separate forms for preventive and corrective work orders

### DIFF
--- a/workorders/forms.py
+++ b/workorders/forms.py
@@ -191,6 +191,22 @@ class WorkOrderUnifiedForm(forms.ModelForm):
 
         return instance
 
+# ---------- Formularios específicos ----------
+class PreventiveWorkOrderForm(WorkOrderUnifiedForm):
+    """Formulario para órdenes preventivas. Oculta campos exclusivos de las correctivas."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Eliminar campos relacionados al flujo correctivo
+        for fname in ("pre_diagnosis", "failure_origin", "severity", "probable_causes"):
+            self.fields.pop(fname, None)
+
+
+class CorrectiveWorkOrderForm(WorkOrderUnifiedForm):
+    """Formulario para órdenes correctivas (incluye diagnóstico, severidad y causas)."""
+
+    pass
+
 # ---------- Formset de TAREAS (categoría/subcategoría) ----------
 TaskFormSet = inlineformset_factory(
     WorkOrder, WorkOrderTask,


### PR DESCRIPTION
## Summary
- Split work order form into `PreventiveWorkOrderForm` and `CorrectiveWorkOrderForm`.
- Adjust unified work order view to pick the appropriate form and redirect helpers with type hints.

## Testing
- `python manage.py test` *(fails: System check identified issues with MaintenancePlanAdmin)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b550ea708322bd66301adbc98055