### PR TITLE
Add dashboard views for fleet vehicle availability and scheduling

### DIFF
--- a/fleet/admin_urls.py
+++ b/fleet/admin_urls.py
@@ -1,0 +1,8 @@
+from django.urls import path
+from .views import vehicles_scheduled_view, vehicles_in_workshop_view, vehicles_available_view
+
+urlpatterns = [
+    path("scheduled/", vehicles_scheduled_view, name="vehicles_scheduled"),
+    path("in-workshop/", vehicles_in_workshop_view, name="vehicles_in_workshop"),
+    path("available/", vehicles_available_view, name="vehicles_available"),
+]

--- a/fleet/urls.py
+++ b/fleet/urls.py
@@ -2,13 +2,11 @@
 
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
-from .views import VehicleViewSet, vehicles_in_repair_view
+from .views import VehicleViewSet
 
 router = DefaultRouter()
 router.register(r"vehicles", VehicleViewSet)
 
 urlpatterns = [
     path("", include(router.urls)),
-    # Página HTML: Vehículos en Taller
-    path("garage/", vehicles_in_repair_view, name="vehicles_in_repair"),
 ]

--- a/fleet/views.py
+++ b/fleet/views.py
@@ -14,10 +14,71 @@ class VehicleViewSet(viewsets.ModelViewSet):
 # --- VISTAS HTML SIMPLES ---
 from django.shortcuts import render
 from django.contrib.admin.views.decorators import staff_member_required
+from django.utils import timezone
+from workorders.models import WorkOrder
+
 
 @staff_member_required
-def vehicles_in_repair_view(request):
-    """Lista de vehículos con estado 'IN_REPAIR'."""
-    from .models import Vehicle
-    vehicles = Vehicle.objects.filter(status="IN_REPAIR").order_by("plate")
-    return render(request, "fleet/vehicles_in_repair.html", {"vehicles": vehicles, "title": "Vehículos en Taller"})
+def vehicles_scheduled_view(request):
+    """Lista de vehículos con OT programada en el futuro."""
+
+    today = timezone.now()
+    vehicles = (
+        Vehicle.objects.filter(
+            workorder__status=WorkOrder.OrderStatus.SCHEDULED,
+            workorder__scheduled_start__isnull=False,
+            workorder__scheduled_start__gt=today,
+        )
+        .order_by("plate")
+        .distinct()
+    )
+    context = {"vehicles": vehicles, "title": "Vehículos con OT Programada"}
+    return render(request, "fleet/vehicles_scheduled.html", context)
+
+
+@staff_member_required
+def vehicles_in_workshop_view(request):
+    """Lista de vehículos actualmente en el taller."""
+
+    today = timezone.now()
+    vehicles = (
+        Vehicle.objects.filter(
+            workorder__check_in_at__isnull=False,
+            workorder__check_in_at__lte=today,
+        )
+        .exclude(
+            workorder__status__in=[
+                WorkOrder.OrderStatus.SCHEDULED,
+                WorkOrder.OrderStatus.COMPLETED,
+                WorkOrder.OrderStatus.VERIFIED,
+                WorkOrder.OrderStatus.CANCELLED,
+            ]
+        )
+        .order_by("plate")
+        .distinct()
+    )
+    context = {"vehicles": vehicles, "title": "Vehículos en Taller"}
+    return render(request, "fleet/vehicles_in_workshop.html", context)
+
+
+@staff_member_required
+def vehicles_available_view(request):
+    """Lista de vehículos sin órdenes de trabajo activas."""
+
+    active_statuses = [
+        WorkOrder.OrderStatus.SCHEDULED,
+        WorkOrder.OrderStatus.IN_RECEPTION,
+        WorkOrder.OrderStatus.IN_SERVICE,
+        WorkOrder.OrderStatus.WAITING_PART,
+        WorkOrder.OrderStatus.PENDING_APPROVAL,
+        WorkOrder.OrderStatus.STOPPED_BY_CLIENT,
+        WorkOrder.OrderStatus.IN_ROAD_TEST,
+    ]
+
+    vehicles = (
+        Vehicle.objects.exclude(workorder__status__in=active_statuses)
+        .order_by("plate")
+        .distinct()
+    )
+    context = {"vehicles": vehicles, "title": "Vehículos Disponibles"}
+    return render(request, "fleet/vehicles_available.html", context)

--- a/templates/admin/index.html
+++ b/templates/admin/index.html
@@ -23,13 +23,18 @@
         <h2>Vista Operativa del Taller</h2>
         <ul style="list-style-type: none; padding-left: 0;">
             <li style="margin-bottom: 10px;">
-                <a href="{% url 'admin:workorders_workorder_changelist' %}?operational_status=in_workshop" class="button" style="padding: 10px 15px; font-size: 14px;">
+                <a href="{% url 'vehicles_in_workshop' %}" class="button" style="padding: 10px 15px; font-size: 14px;">
                     Ver Vehículos en Taller ({{ in_workshop_count }})
                 </a>
             </li>
-            <li>
-                <a href="{% url 'admin:workorders_workorder_changelist' %}?operational_status=scheduled" class="button" style="padding: 10px 15px; font-size: 14px;">
+            <li style="margin-bottom: 10px;">
+                <a href="{% url 'vehicles_scheduled' %}" class="button" style="padding: 10px 15px; font-size: 14px;">
                     Ver Vehículos Programados ({{ scheduled_count }})
+                </a>
+            </li>
+            <li>
+                <a href="{% url 'vehicles_available' %}" class="button" style="padding: 10px 15px; font-size: 14px;">
+                    Ver Vehículos Disponibles ({{ available_count }})
                 </a>
             </li>
         </ul>

--- a/templates/fleet/vehicles_available.html
+++ b/templates/fleet/vehicles_available.html
@@ -9,8 +9,6 @@
             <th>Placa</th>
             <th>Marca</th>
             <th>Modelo</th>
-            <th>Kilometraje</th>
-            <th>Notas</th>
           </tr>
         </thead>
         <tbody>
@@ -19,14 +17,12 @@
               <td>{{ v.plate }}</td>
               <td>{{ v.brand }}</td>
               <td>{{ v.model }}</td>
-              <td>{{ v.current_odometer_km|default:"—" }}</td>
-              <td>{{ v.notes|default:"" }}</td>
             </tr>
           {% endfor %}
         </tbody>
       </table>
     {% else %}
-      <p>No hay vehículos en reparación.</p>
+      <p>No hay vehículos disponibles.</p>
     {% endif %}
   </div>
 {% endblock %}

--- a/templates/fleet/vehicles_in_workshop.html
+++ b/templates/fleet/vehicles_in_workshop.html
@@ -1,0 +1,32 @@
+{% extends "admin/base_site.html" %}
+{% block content %}
+  <div id="content-main">
+    <h1>{{ title }}</h1>
+    {% if vehicles %}
+      <table class="listing">
+        <thead>
+          <tr>
+            <th>Placa</th>
+            <th>Marca</th>
+            <th>Modelo</th>
+            <th>Estado OT</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for v in vehicles %}
+            {% with v.workorder_set.exclude(status__in=['SCHEDULED','COMPLETED','VERIFIED','CANCELLED']).first as wo %}
+            <tr>
+              <td>{{ v.plate }}</td>
+              <td>{{ v.brand }}</td>
+              <td>{{ v.model }}</td>
+              <td>{% if wo %}{{ wo.get_status_display }}{% else %}—{% endif %}</td>
+            </tr>
+            {% endwith %}
+          {% endfor %}
+        </tbody>
+      </table>
+    {% else %}
+      <p>No hay vehículos en taller.</p>
+    {% endif %}
+  </div>
+{% endblock %}

--- a/templates/fleet/vehicles_scheduled.html
+++ b/templates/fleet/vehicles_scheduled.html
@@ -1,0 +1,32 @@
+{% extends "admin/base_site.html" %}
+{% block content %}
+  <div id="content-main">
+    <h1>{{ title }}</h1>
+    {% if vehicles %}
+      <table class="listing">
+        <thead>
+          <tr>
+            <th>Placa</th>
+            <th>Marca</th>
+            <th>Modelo</th>
+            <th>Inicio Programado</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for v in vehicles %}
+            {% with v.workorder_set.filter(status='SCHEDULED').first as wo %}
+            <tr>
+              <td>{{ v.plate }}</td>
+              <td>{{ v.brand }}</td>
+              <td>{{ v.model }}</td>
+              <td>{% if wo and wo.scheduled_start %}{{ wo.scheduled_start|date:"Y-m-d H:i" }}{% else %}—{% endif %}</td>
+            </tr>
+            {% endwith %}
+          {% endfor %}
+        </tbody>
+      </table>
+    {% else %}
+      <p>No hay vehículos con OTs programadas.</p>
+    {% endif %}
+  </div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add views for vehicles with scheduled work orders, currently in workshop, and available
- create HTML templates and URL routes for new vehicle views
- surface links with counts on admin dashboard

## Testing
- `python manage.py test` *(fails: admin.E033/E108/E116 in MaintenancePlanAdmin)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b5539190832297d779384b6ec35b