### PR TITLE
Add vehicle_type validation and tests

### DIFF
--- a/fleet/serializers.py
+++ b/fleet/serializers.py
@@ -7,6 +7,24 @@ from .models import Vehicle
 class VehicleSerializer(serializers.ModelSerializer):
     """Serializer for :class:`~fleet.models.Vehicle`."""
 
+    def validate_vehicle_type(self, value: str) -> str:
+        """Ensure ``vehicle_type`` matches the allowed choices.
+
+        Django's ``ChoiceField`` normally validates input, but we add an
+        explicit check to provide a clearer error message and guard against
+        unexpected values that could bubble up as 500 errors.
+        """
+        allowed = {
+            choice[0]
+            for choice in Vehicle._meta.get_field("vehicle_type").choices
+        }
+        if value not in allowed:
+            allowed_display = ", ".join(sorted(allowed))
+            raise serializers.ValidationError(
+                f"Invalid vehicle_type '{value}'. Allowed values are: {allowed_display}."
+            )
+        return value
+
     class Meta:
         model = Vehicle
         fields = "__all__"  # Incluir todos los campos del modelo

--- a/fleet/tests/test_vehicle_type_validation.py
+++ b/fleet/tests/test_vehicle_type_validation.py
@@ -1,0 +1,27 @@
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+from django.test import TestCase
+
+
+class VehicleTypeValidationTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.url = reverse("vehicle-list")
+        self.base_payload = {
+            "plate": "TEST123",
+            "brand": "Test",
+            "linea": "Model",
+            "modelo": 2024,
+        }
+
+    def test_invalid_vehicle_type_returns_400(self):
+        payload = {**self.base_payload, "vehicle_type": "INVALID"}
+        response = self.client.post(self.url, payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("vehicle_type", response.data)
+
+    def test_missing_vehicle_type_returns_400(self):
+        response = self.client.post(self.url, self.base_payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("vehicle_type", response.data)

--- a/fleet/views.py
+++ b/fleet/views.py
@@ -1,6 +1,8 @@
 """Viewsets for the fleet application."""
 
-from rest_framework import viewsets
+from rest_framework import viewsets, status
+from rest_framework.response import Response
+from rest_framework.exceptions import ValidationError
 from .models import Vehicle
 from .serializers import VehicleSerializer
 
@@ -10,6 +12,32 @@ class VehicleViewSet(viewsets.ModelViewSet):
 
     queryset = Vehicle.objects.all()
     serializer_class = VehicleSerializer
+
+    def _handle_request(self, request, partial=False, instance=None):
+        serializer = self.get_serializer(
+            instance, data=request.data, partial=partial
+        ) if instance else self.get_serializer(data=request.data)
+        try:
+            serializer.is_valid(raise_exception=True)
+            self.perform_create(serializer) if not instance else self.perform_update(serializer)
+        except ValidationError as exc:
+            return Response(exc.detail, status=status.HTTP_400_BAD_REQUEST)
+        except Exception:
+            return Response(
+                {"detail": "Invalid vehicle data."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        headers = self.get_success_headers(serializer.data) if not instance else {}
+        status_code = status.HTTP_201_CREATED if not instance else status.HTTP_200_OK
+        return Response(serializer.data, status=status_code, headers=headers)
+
+    def create(self, request, *args, **kwargs):
+        return self._handle_request(request)
+
+    def update(self, request, *args, **kwargs):
+        partial = kwargs.pop("partial", False)
+        instance = self.get_object()
+        return self._handle_request(request, partial=partial, instance=instance)
 
 # --- VISTAS HTML SIMPLES ---
 from django.shortcuts import render


### PR DESCRIPTION
## Summary
- validate `vehicle_type` and provide friendly error messages
- guard create/update operations in `VehicleViewSet` so invalid data returns 400
- add tests for invalid or missing `vehicle_type`

## Testing
- `python manage.py test fleet.tests.test_vehicle_type_validation`

------
https://chatgpt.com/codex/tasks/task_e_68b5bb190944832294ddac9e18e265d4