### PR TITLE
Expose maintenance manual details on work order form

### DIFF
--- a/workorders/templates/workorders/order_full_form.html
+++ b/workorders/templates/workorders/order_full_form.html
@@ -89,6 +89,19 @@
         {% if form.fields.external_cost %}<div><label>{{ form.external_cost.label }}</label>{{ form.external_cost }}</div>{% endif %}
         {% if form.fields.service_cost %}<div><label>{{ form.service_cost.label }}</label>{{ form.service_cost }}</div>{% endif %}
         {% if form.fields.total_cost %}<div><label>{{ form.total_cost.label }}</label>{{ form.total_cost }}</div>{% endif %}
+        {% if manual %}
+        <div style="grid-column:1/-1">
+          <label>Manual de mantenimiento</label>
+          <p>{{ manual.name }}</p>
+          {% if manual.tasks.all %}
+          <ul>
+            {% for mt in manual.tasks.all %}
+            <li>{{ mt.km_interval }} km - {{ mt.description }}</li>
+            {% endfor %}
+          </ul>
+          {% endif %}
+        </div>
+        {% endif %}
       </div>
 
       <!-- Conductor -->

--- a/workorders/views.py
+++ b/workorders/views.py
@@ -145,6 +145,23 @@ def workorder_unified(request, pk=None):
     datetime_real_names = [f for f in form_cls.dynamic_datetime_fields if f in form.fields]
     dynamic_dt_bfs = [form[name] for name in datetime_real_names]
 
+    # Manual de mantenimiento del vehículo seleccionado
+    vehicle_id = (
+        request.POST.get("vehicle")
+        or request.GET.get("vehicle")
+        or (ot.vehicle_id if ot else None)
+    )
+    manual = None
+    if vehicle_id:
+        plan = (
+            MaintenancePlan.objects
+            .filter(vehicle_id=vehicle_id)
+            .select_related("manual")
+            .first()
+        )
+        if plan:
+            manual = plan.manual
+
     return render(request, "workorders/order_full_form.html", {
         "form": form,
         "task_fs": task_fs,
@@ -152,6 +169,7 @@ def workorder_unified(request, pk=None):
         "ot": ot,
         "dynamic_dt_bfs": dynamic_dt_bfs,  # ← usar esto en la plantilla
         "title": ("Editar OT" if ot else "Nueva OT"),
+        "manual": manual,
         # Quick-create forms (si existen)
         "qc_vehicle": QuickCreateVehicleForm() if QuickCreateVehicleForm._meta.fields else None,
         "qc_driver": QuickCreateDriverForm() if QuickCreateDriverForm._meta.fields else None,


### PR DESCRIPTION
## Summary
- Fetch maintenance manual linked to the selected vehicle in the unified work order view
- Display manual name and its tasks in the work order form

## Testing
- `python manage.py test` *(fails: ImportError: 'tests' module incorrectly imported from '/workspace/sigma-project/fleet/tests')*
- `python manage.py test workorders`
- `python manage.py shell` *(fails: django.db.utils.OperationalError: table fleet_vehicle has no column named linea)*

------
https://chatgpt.com/codex/tasks/task_e_68b5bec3097c8322ab8ab811cf101500