### PR TITLE
Register maintenance manual models in admin and add dashboard link

### DIFF
--- a/templates/admin/index.html
+++ b/templates/admin/index.html
@@ -52,6 +52,18 @@
         </ul>
     </div>
 
+    <!-- Bloque de Manuales de Mantenimiento -->
+    <div style="padding: 20px; background: #fff8e1; border: 1px solid #ffe082; margin-bottom: 20px; border-radius: 8px;">
+        <h2>Manuales de Mantenimiento</h2>
+        <ul style="list-style-type: none; padding-left: 0;">
+            <li>
+                <a href="{% url 'admin:workorders_maintenancemanual_changelist' %}" class="button" style="padding: 10px 15px; font-size: 14px;">
+                    Ver Manuales de Mantenimiento
+                </a>
+            </li>
+        </ul>
+    </div>
+
     <!-- Contenido original del admin (listas de modelos) -->
     {{ block.super }}
 </div>

--- a/workorders/admin.py
+++ b/workorders/admin.py
@@ -2,7 +2,12 @@
 from django.contrib import admin
 from django.shortcuts import redirect
 from django.urls import reverse
-from .models import WorkOrder, WorkOrderNote
+from .models import (
+    WorkOrder,
+    WorkOrderNote,
+    MaintenanceManual,
+    ManualTask,
+)
 
 @admin.register(WorkOrder)
 class WorkOrderAdmin(admin.ModelAdmin):
@@ -24,7 +29,24 @@ class WorkOrderNoteAdmin(admin.ModelAdmin):
     list_select_related = ("work_order", "author") if hasattr(WorkOrderNote, "author") else ("work_order",)
 
 
-# --- Registro de Manuales de Mantenimiento (solo lectura) ---
+# --- Registro de Manuales de Mantenimiento ---
+
+
+@admin.register(MaintenanceManual)
+class MaintenanceManualAdmin(admin.ModelAdmin):
+    list_display = ("name", "fuel_type")
+    search_fields = ("name",)
+    list_filter = ("fuel_type",)
+
+
+@admin.register(ManualTask)
+class ManualTaskAdmin(admin.ModelAdmin):
+    list_display = ("manual", "km_interval", "description")
+    search_fields = ("manual__name", "description")
+    list_filter = ("manual",)
+
+
+# --- Registro de Planes de Mantenimiento (solo lectura) ---
 from django.utils.html import format_html
 
 try:


### PR DESCRIPTION
## Summary
- Register MaintenanceManual and ManualTask models in Django admin
- Add dashboard link to maintenance manual changelist for easy access

## Testing
- `python manage.py test` *(fails: ImportError: 'tests' module incorrectly imported from '/workspace/sigma-project/fleet/tests'. Expected '/workspace/sigma-project/fleet'. Is this module globally installed?)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c15c9048832290725128b50421c1