### PR TITLE
Honor posted order type when selecting work order form

### DIFF
--- a/workorders/tests.py
+++ b/workorders/tests.py
@@ -1,5 +1,56 @@
 """Tests for the workorders application."""
 
 from django.test import TestCase
+from django.test.utils import override_settings
+from django.urls import reverse
+from django.contrib.auth import get_user_model
 
-# Create your tests here.
+from core.models import Zone
+from fleet.models import Vehicle
+from .models import WorkOrder
+
+
+@override_settings(MIGRATION_MODULES={"fleet": None})
+class WorkOrderUnifiedViewTests(TestCase):
+    """Integration tests for the unified work order view."""
+
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_user(
+            username="staff", password="pass", is_staff=True
+        )
+        self.client.force_login(self.user)
+
+        self.zone = Zone.objects.create(name="Z1")
+        self.vehicle = Vehicle.objects.create(
+            plate="ABC123",
+            brand="Brand",
+            linea="Line",
+            modelo=2020,
+            vehicle_type=Vehicle.VehicleType.AUTOMOVIL,
+            fuel_type=Vehicle.FuelType.DIESEL,
+            status=Vehicle.VehicleStatus.ACTIVE,
+            current_zone=self.zone,
+        )
+
+    def test_corrective_order_saves_diagnostic(self):
+        """Creating a corrective OT should persist the diagnostic field."""
+        url = reverse("workorders_unified_new")
+        data = {
+            "order_type": WorkOrder.OrderType.CORRECTIVE,
+            "vehicle": str(self.vehicle.id),
+            "status": WorkOrder.OrderStatus.SCHEDULED,
+            "priority": WorkOrder.Priority.MEDIUM,
+            "description": "Engine issue",
+            "pre_diagnosis": "Initial diagnosis",
+            # Formset management data without tasks
+            "tasks-TOTAL_FORMS": "0",
+            "tasks-INITIAL_FORMS": "0",
+            "tasks-MIN_NUM_FORMS": "0",
+            "tasks-MAX_NUM_FORMS": "1000",
+        }
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, 302)
+        wo = WorkOrder.objects.get()
+        self.assertEqual(wo.order_type, WorkOrder.OrderType.CORRECTIVE)
+        self.assertEqual(wo.pre_diagnosis, "Initial diagnosis")

--- a/workorders/views.py
+++ b/workorders/views.py
@@ -51,9 +51,11 @@ def workorder_unified(request, pk=None):
 
     # Determinar qué formulario usar (preventivo o correctivo)
     form_cls = PreventiveWorkOrderForm
-    if ot:
-        if str(ot.order_type).upper().startswith("CORRECT"):
-            form_cls = CorrectiveWorkOrderForm
+    post_type = request.POST.get("order_type", "") if request.method == "POST" else ""
+    if post_type.lower().startswith("corr"):
+        form_cls = CorrectiveWorkOrderForm
+    elif ot and str(ot.order_type).upper().startswith("CORRECT"):
+        form_cls = CorrectiveWorkOrderForm
     else:
         t = request.GET.get("type", "")
         if t.lower().startswith("corr"):


### PR DESCRIPTION
## Summary
- choose corrective or preventive form in `workorder_unified` using `request.POST['order_type']`
- add integration test ensuring a corrective order saves its diagnostic

## Testing
- `python manage.py test workorders` *(fails: closing parenthesis ')' does not match opening '[' in fleet/migrations/0008_alter_vehicle_vehicle_type.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c58b3f208322860136c22fb06666