### PR TITLE
Add dynamic task rows in work order form

### DIFF
--- a/fleet/migrations/0008_alter_vehicle_vehicle_type.py
+++ b/fleet/migrations/0008_alter_vehicle_vehicle_type.py
@@ -1,10 +1,7 @@
-
-
 from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("fleet", "0007_rename_vehicle_fields"),
     ]
@@ -14,11 +11,14 @@ class Migration(migrations.Migration):
             model_name="vehicle",
             name="vehicle_type",
             field=models.CharField(
+                "Tipo de Vehículo",
+                max_length=10,
                 choices=[
                     ("AUTOMOVIL", "Automóvil"),
                     ("MICROBUS", "Microbús"),
-
-                verbose_name="Tipo de Vehículo",
+                    ("BUS", "Bus"),
+                ],
+                help_text="Seleccione el tipo de vehículo",
             ),
         ),
     ]

--- a/workorders/templates/workorders/order_full_form.html
+++ b/workorders/templates/workorders/order_full_form.html
@@ -187,7 +187,7 @@
           </div>
 
           {{ task_fs.management_form }}
-          <table>
+          <table id="tasks-table">
           <thead>
             <tr><th>Categoría</th><th>Subcategoría</th><th>Descripción</th><th>Horas</th><th>Tercero</th><th>Tarifa</th><th>Eliminar</th></tr>
           </thead>
@@ -205,6 +205,20 @@
           {% endfor %}
         </tbody>
         </table>
+        <div class="actions" style="margin-top:10px;">
+          <button type="button" class="btn" id="add-task-btn">Agregar tarea</button>
+        </div>
+        <template id="task-empty-form">
+          <tr>
+            <td>{{ task_fs.empty_form.category }}</td>
+            <td>{{ task_fs.empty_form.subcategory }}</td>
+            <td>{{ task_fs.empty_form.description }}</td>
+            <td>{{ task_fs.empty_form.hours_spent }}</td>
+            <td>{{ task_fs.empty_form.is_external }}</td>
+            <td>{{ task_fs.empty_form.labor_rate }}</td>
+            <td>{{ task_fs.empty_form.DELETE }}</td>
+          </tr>
+        </template>
       </div>
 
       <!-- Novedades -->
@@ -257,6 +271,20 @@
       document.addEventListener("change", function(e){
         if(e.target && e.target.id === "id_order_type") toggleCorrective();
       });
-      document.addEventListener("DOMContentLoaded", toggleCorrective);
+      document.addEventListener("DOMContentLoaded", function(){
+        toggleCorrective();
+        const addBtn = document.getElementById("add-task-btn");
+        const totalForms = document.getElementById("id_tasks-TOTAL_FORMS");
+        const tableBody = document.querySelector("#tasks-table tbody");
+        const tmpl = document.getElementById("task-empty-form");
+        if(addBtn && totalForms && tableBody && tmpl){
+          addBtn.addEventListener("click", function(){
+            const idx = parseInt(totalForms.value, 10);
+            const newRowHtml = tmpl.innerHTML.replace(/__prefix__/g, idx);
+            tableBody.insertAdjacentHTML('beforeend', newRowHtml);
+            totalForms.value = idx + 1;
+          });
+        }
+      });
 </script>
 {% endblock %}

--- a/workorders/tests/test_task_formset.py
+++ b/workorders/tests/test_task_formset.py
@@ -1,0 +1,59 @@
+from django.urls import reverse
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+from fleet.models import Vehicle
+from workorders.models import WorkOrder, WorkOrderTask
+
+
+class TaskFormSetTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_user(
+            username="staff", password="pass", is_staff=True
+        )
+        self.client.force_login(self.user)
+        self.vehicle = Vehicle.objects.create(
+            plate="ABC123",
+            brand="Toyota",
+            linea="Corolla",
+            modelo=2020,
+            vehicle_type=Vehicle.VehicleType.AUTOMOVIL,
+        )
+
+    def test_can_add_multiple_tasks(self):
+        url = reverse("workorders_unified_new") + "?type=corrective"
+        data = {
+            "order_type": WorkOrder.OrderType.CORRECTIVE,
+            "vehicle": self.vehicle.id,
+            "status": WorkOrder.OrderStatus.SCHEDULED,
+            "priority": WorkOrder.Priority.MEDIUM,
+            "description": "Test order",
+            "tasks-TOTAL_FORMS": "2",
+            "tasks-INITIAL_FORMS": "0",
+            "tasks-MIN_NUM_FORMS": "0",
+            "tasks-MAX_NUM_FORMS": "1000",
+            "tasks-0-category": "",
+            "tasks-0-subcategory": "",
+            "tasks-0-description": "Task 1",
+            "tasks-0-hours_spent": "1",
+            "tasks-0-is_external": "",
+            "tasks-0-labor_rate": "",
+            "tasks-0-DELETE": "",
+            "tasks-1-category": "",
+            "tasks-1-subcategory": "",
+            "tasks-1-description": "Task 2",
+            "tasks-1-hours_spent": "2",
+            "tasks-1-is_external": "",
+            "tasks-1-labor_rate": "",
+            "tasks-1-DELETE": "",
+        }
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, 302)
+        ot = WorkOrder.objects.get()
+        self.assertEqual(ot.tasks.count(), 2)
+        self.assertTrue(
+            WorkOrderTask.objects.filter(work_order=ot, description="Task 1").exists()
+        )
+        self.assertTrue(
+            WorkOrderTask.objects.filter(work_order=ot, description="Task 2").exists()
+        )


### PR DESCRIPTION
## Summary
- add "Agregar tarea" button and JS to clone empty task rows in work order form
- cover TaskFormSet with a test posting multiple tasks
- fix broken vehicle_type migration so tests run

## Testing
- `python manage.py test fleet.tests.test_vehicle_type_validation workorders.tests.test_task_formset`

------
https://chatgpt.com/codex/tasks/task_e_68b5c58ceeb883228c27235c565317c8