### PR TITLE
feat: allow selecting probable causes

### DIFF
--- a/workorders/templates/admin/workorders/order_full_form.html
+++ b/workorders/templates/admin/workorders/order_full_form.html
@@ -130,7 +130,7 @@
           <div><label>Severidad</label>{{ form.severity }}</div>
           <div><label>Origen de la falla</label>{{ form.failure_origin }}</div>
           <div style="grid-column:1/-1"><label>Pre-diagnóstico</label>{{ form.pre_diagnosis }}</div>
-          <div style="grid-column:1/-1"><label>Causas probables (se registra como novedad)</label>{{ form.probable_causes }}</div>
+          <div style="grid-column:1/-1"><label>Causas probables</label>{{ form.probable_causes }}</div>
         </div>
       </div>
 
@@ -191,7 +191,7 @@
         <h2 class="section-title">Novedades de OT</h2>
         <div class="grid cols-2">
           <div>
-            <p class="muted">Las novedades nuevas se agregan desde “Comentario inicial” o “Causas probables” al guardar.</p>
+            <p class="muted">Las novedades nuevas se agregan desde “Comentario inicial” al guardar.</p>
             <div class="actions"><button class="btn" type="submit">Guardar</button></div>
           </div>
           <div>

--- a/workorders/templates/workorders/order_full_form.html
+++ b/workorders/templates/workorders/order_full_form.html
@@ -127,7 +127,7 @@
           <div><label>Severidad</label>{{ form.severity }}</div>
           <div><label>Origen de la falla</label>{{ form.failure_origin }}</div>
           <div style="grid-column:1/-1"><label>Pre-diagnóstico</label>{{ form.pre_diagnosis }}</div>
-          <div style="grid-column:1/-1"><label>Causas probables (se registra como novedad)</label>{{ form.probable_causes }}</div>
+          <div style="grid-column:1/-1"><label>Causas probables</label>{{ form.probable_causes }}</div>
         </div>
       </div>
 
@@ -206,7 +206,7 @@
         <h2 class="section-title">Novedades de OT</h2>
         <div class="grid cols-2">
           <div>
-            <p class="muted">Las novedades nuevas se agregan desde “Comentario inicial” o “Causas probables” al guardar.</p>
+            <p class="muted">Las novedades nuevas se agregan desde “Comentario inicial” al guardar.</p>
             <div class="submit-row"><input type="submit" value="Guardar" class="default"></div>
           </div>
           <div>


### PR DESCRIPTION
## Summary
- replace text probable cause input with multi-select checkboxes
- persist selected probable causes directly on work orders
- update templates to show selection and adjust notes text

## Testing
- `python manage.py test` *(fails: 'tests' module incorrectly imported)*
- `pytest` *(fails: settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ca0c687c8322910d61cbc62c63ec