### PR TITLE
Handle driver link updates in WorkOrderUnifiedForm

### DIFF
--- a/workorders/forms.py
+++ b/workorders/forms.py
@@ -98,6 +98,32 @@ class WorkOrderUnifiedForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+        # Inicializar conductor existente
+        if (
+            Driver
+            and WorkOrderDriver
+            and self.instance
+            and getattr(self.instance, "pk", None)
+            and 'driver' in self.fields
+            and 'driver_responsibility' in self.fields
+        ):
+            try:
+                wod = (
+                    WorkOrderDriver.objects
+                    .filter(work_order=self.instance)
+                    .select_related('driver')
+                    .first()
+                )
+                if wod:
+                    self.fields['driver'].initial = getattr(wod, 'driver', None)
+                    self.fields['driver_responsibility'].initial = getattr(
+                        wod,
+                        'responsibility_percent',
+                        None,
+                    )
+            except Exception:
+                pass
+
         # Campos datetime reales si existen
         for fname in self.dynamic_datetime_fields:
             if _field_exists(WorkOrder, fname):
@@ -137,6 +163,8 @@ class WorkOrderUnifiedForm(forms.ModelForm):
                     work_order=instance, driver=driver,
                     defaults={'responsibility_percent': resp}
                 )
+            else:
+                WorkOrderDriver.objects.filter(work_order=instance).delete()
 
         # Comentario inicial y causas -> WorkOrderNote
         comment = self.cleaned_data.get('first_comment')


### PR DESCRIPTION
## Summary
- Initialize `driver` and `driver_responsibility` fields from existing `WorkOrderDriver`
- Remove `WorkOrderDriver` link when `driver` field is left empty

## Testing
- `python manage.py test` *(fails: ImportError: 'tests' module incorrectly imported)*
- `pytest` *(fails: django.core.exceptions.ImproperlyConfigured: Requested setting REST_FRAMEWORK, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ca0e87e08322ae4a580eaef719d2