### PR TITLE
Remove order type from specialized work order forms

### DIFF
--- a/workorders/forms.py
+++ b/workorders/forms.py
@@ -197,15 +197,29 @@ class PreventiveWorkOrderForm(WorkOrderUnifiedForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        # Se fuerza el tipo y se oculta el campo correspondiente
+        self.fields.pop('order_type', None)
         # Eliminar campos relacionados al flujo correctivo
         for fname in ("pre_diagnosis", "failure_origin", "severity", "probable_causes"):
             self.fields.pop(fname, None)
 
+    def save(self, user=None, commit=True):
+        # Asignar automáticamente el tipo preventivo antes de guardar
+        self.cleaned_data['order_type'] = WorkOrder.OrderType.PREVENTIVE
+        return super().save(user=user, commit=commit)
+
 
 class CorrectiveWorkOrderForm(WorkOrderUnifiedForm):
     """Formulario para órdenes correctivas (incluye diagnóstico, severidad y causas)."""
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Se fuerza el tipo y se oculta el campo correspondiente
+        self.fields.pop('order_type', None)
 
-    pass
+    def save(self, user=None, commit=True):
+        # Asignar automáticamente el tipo correctivo antes de guardar
+        self.cleaned_data['order_type'] = WorkOrder.OrderType.CORRECTIVE
+        return super().save(user=user, commit=commit)
 
 # ---------- Formset de TAREAS (categoría/subcategoría) ----------
 TaskFormSet = inlineformset_factory(

--- a/workorders/templates/admin/workorders/order_full_form.html
+++ b/workorders/templates/admin/workorders/order_full_form.html
@@ -39,7 +39,8 @@
       <!-- Datos base -->
       <div class="card grid cols-3">
         <div>
-          <label>Tipo de OT *</label>{{ form.order_type }}
+          <label>Tipo de OT</label>
+          <input type="text" value="{{ order_type_label }}" disabled>
         </div>
         <div>
           <label>Vehículo *</label>{{ form.vehicle }}
@@ -123,6 +124,7 @@
       </div>
       {% endif %}
 
+      {% if show_corrective %}
       <!-- Sección Correctivo -->
       <div class="card" id="corrective-section">
         <h2 class="section-title"><span class="badge">Solo Correctivo</span> Diagnóstico</h2>
@@ -133,6 +135,7 @@
           <div style="grid-column:1/-1"><label>Causas probables (se registra como novedad)</label>{{ form.probable_causes }}</div>
         </div>
       </div>
+      {% endif %}
 
       <!-- Tareas -->
       <div class="card">
@@ -215,26 +218,6 @@
     </form>
   </div>
 
-  <script>
-    // Mostrar/Ocultar "Correctivo" robusto (por value y por texto visible)
-    function isCorrectiveOption(sel){
-      if(!sel) return false;
-      const val = (sel.value || "").toUpperCase();
-      if(val.includes("CORRECTIVE")) return true;
-      const opt = sel.options[sel.selectedIndex];
-      const text = (opt && opt.text ? opt.text : "").toLowerCase();
-      return text.includes("correctiv");
-    }
-    function toggleCorrective(){
-      const sel = document.getElementById("id_order_type");
-      const block = document.getElementById("corrective-section");
-      if(!sel || !block) return;
-      block.style.display = isCorrectiveOption(sel) ? "block" : "none";
-    }
-    document.addEventListener("change", function(e){
-      if(e.target && e.target.id === "id_order_type") toggleCorrective();
-    });
-    document.addEventListener("DOMContentLoaded", toggleCorrective);
-  </script>
+  
 </body>
 </html>

--- a/workorders/templates/workorders/order_full_form.html
+++ b/workorders/templates/workorders/order_full_form.html
@@ -26,7 +26,8 @@
       <!-- Datos base -->
       <div class="card grid cols-3">
         <div>
-          <label>Tipo de OT *</label>{{ form.order_type }}
+          <label>Tipo de OT</label>
+          <input type="text" value="{{ order_type_label }}" disabled>
         </div>
         <div>
           <label>Vehículo *</label>{{ form.vehicle }}
@@ -120,6 +121,7 @@
       </div>
       {% endif %}
 
+      {% if show_corrective %}
       <!-- Sección Correctivo -->
       <div class="card" id="corrective-section">
         <h2 class="section-title"><span class="badge">Solo Correctivo</span> Diagnóstico</h2>
@@ -130,6 +132,7 @@
           <div style="grid-column:1/-1"><label>Causas probables (se registra como novedad)</label>{{ form.probable_causes }}</div>
         </div>
       </div>
+      {% endif %}
 
       <!-- Tareas -->
       <div class="card">
@@ -234,25 +237,7 @@
 {% block extrahead %}
 <script>
       // Mostrar/Ocultar "Correctivo" robusto (por value y por texto visible)
-      function isCorrectiveOption(sel){
-        if(!sel) return false;
-        const val = (sel.value || "").toUpperCase();
-        if(val.includes("CORRECTIVE")) return true;
-        const opt = sel.options[sel.selectedIndex];
-        const text = (opt && opt.text ? opt.text : "").toLowerCase();
-        return text.includes("correctiv");
-      }
-      function toggleCorrective(){
-        const sel = document.getElementById("id_order_type");
-        const block = document.getElementById("corrective-section");
-        if(!sel || !block) return;
-        block.style.display = isCorrectiveOption(sel) ? "block" : "none";
-      }
-      document.addEventListener("change", function(e){
-        if(e.target && e.target.id === "id_order_type") toggleCorrective();
-      });
       document.addEventListener("DOMContentLoaded", function(){
-        toggleCorrective();
         const addBtn = document.getElementById("add-task-btn");
         const totalForms = document.getElementById("id_tasks-TOTAL_FORMS");
         const tableBody = document.querySelector("#tasks-table tbody");

--- a/workorders/tests.py
+++ b/workorders/tests.py
@@ -35,9 +35,8 @@ class WorkOrderUnifiedViewTests(TestCase):
 
     def test_corrective_order_saves_diagnostic(self):
         """Creating a corrective OT should persist the diagnostic field."""
-        url = reverse("workorders_unified_new")
+        url = reverse("workorders_unified_new") + "?type=corrective"
         data = {
-            "order_type": WorkOrder.OrderType.CORRECTIVE,
             "vehicle": str(self.vehicle.id),
             "status": WorkOrder.OrderStatus.SCHEDULED,
             "priority": WorkOrder.Priority.MEDIUM,

--- a/workorders/tests/test_task_formset.py
+++ b/workorders/tests/test_task_formset.py
@@ -23,7 +23,6 @@ class TaskFormSetTests(TestCase):
     def test_can_add_multiple_tasks(self):
         url = reverse("workorders_unified_new") + "?type=corrective"
         data = {
-            "order_type": WorkOrder.OrderType.CORRECTIVE,
             "vehicle": self.vehicle.id,
             "status": WorkOrder.OrderStatus.SCHEDULED,
             "priority": WorkOrder.Priority.MEDIUM,

--- a/workorders/views.py
+++ b/workorders/views.py
@@ -51,15 +51,14 @@ def workorder_unified(request, pk=None):
 
     # Determinar qué formulario usar (preventivo o correctivo)
     form_cls = PreventiveWorkOrderForm
-    post_type = request.POST.get("order_type", "") if request.method == "POST" else ""
-    if post_type.lower().startswith("corr"):
-        form_cls = CorrectiveWorkOrderForm
-    elif ot and str(ot.order_type).upper().startswith("CORRECT"):
+    if ot and str(ot.order_type).upper().startswith("CORRECT"):
         form_cls = CorrectiveWorkOrderForm
     else:
         t = request.GET.get("type", "")
         if t.lower().startswith("corr"):
             form_cls = CorrectiveWorkOrderForm
+
+    is_corrective = (form_cls is CorrectiveWorkOrderForm)
 
     # ---- Quick-Create (crear sin salir) ----
     if request.method == "POST" and request.POST.get("qc_target"):
@@ -172,6 +171,12 @@ def workorder_unified(request, pk=None):
         "dynamic_dt_bfs": dynamic_dt_bfs,  # ← usar esto en la plantilla
         "title": ("Editar OT" if ot else "Nueva OT"),
         "manual": manual,
+        "show_corrective": is_corrective,
+        "order_type_label": (
+            WorkOrder.OrderType.CORRECTIVE.label
+            if is_corrective
+            else WorkOrder.OrderType.PREVENTIVE.label
+        ),
         # Quick-create forms (si existen)
         "qc_vehicle": QuickCreateVehicleForm() if QuickCreateVehicleForm._meta.fields else None,
         "qc_driver": QuickCreateDriverForm() if QuickCreateDriverForm._meta.fields else None,


### PR DESCRIPTION
## Summary
- Fix work order forms to set order type automatically without exposing the field
- Hide corrective-only section for preventive orders and display type as read-only
- Pass clear flag from view to template and update tests

## Testing
- `python manage.py test workorders.tests`
- `python manage.py test workorders.tests.test_task_formset`


------
https://chatgpt.com/codex/tasks/task_e_68b5ca0fc2b88322a4f20b347d4018ab