### PR TITLE
Extract order form JavaScript to static file

### DIFF
--- a/static/workorders/order_full_form.js
+++ b/static/workorders/order_full_form.js
@@ -1,0 +1,33 @@
+// Mostrar/Ocultar "Correctivo" robusto (por value y por texto visible)
+function isCorrectiveOption(sel){
+  if(!sel) return false;
+  const val = (sel.value || "").toUpperCase();
+  if(val.includes("CORRECTIVE")) return true;
+  const opt = sel.options[sel.selectedIndex];
+  const text = (opt && opt.text ? opt.text : "").toLowerCase();
+  return text.includes("correctiv");
+}
+function toggleCorrective(){
+  const sel = document.getElementById("id_order_type");
+  const block = document.getElementById("corrective-section");
+  if(!sel || !block) return;
+  block.style.display = isCorrectiveOption(sel) ? "block" : "none";
+}
+document.addEventListener("change", function(e){
+  if(e.target && e.target.id === "id_order_type") toggleCorrective();
+});
+document.addEventListener("DOMContentLoaded", function(){
+  toggleCorrective();
+  const addBtn = document.getElementById("add-task-btn");
+  const totalForms = document.getElementById("id_tasks-TOTAL_FORMS");
+  const tableBody = document.querySelector("#tasks-table tbody");
+  const tmpl = document.getElementById("task-empty-form");
+  if(addBtn && totalForms && tableBody && tmpl){
+    addBtn.addEventListener("click", function(){
+      const idx = parseInt(totalForms.value, 10);
+      const newRowHtml = tmpl.innerHTML.replace(/__prefix__/g, idx);
+      tableBody.insertAdjacentHTML('beforeend', newRowHtml);
+      totalForms.value = idx + 1;
+    });
+  }
+});

--- a/workorders/templates/workorders/order_full_form.html
+++ b/workorders/templates/workorders/order_full_form.html
@@ -232,39 +232,5 @@
 {% endblock %}
 
 {% block extrahead %}
-<script>
-      // Mostrar/Ocultar "Correctivo" robusto (por value y por texto visible)
-      function isCorrectiveOption(sel){
-        if(!sel) return false;
-        const val = (sel.value || "").toUpperCase();
-        if(val.includes("CORRECTIVE")) return true;
-        const opt = sel.options[sel.selectedIndex];
-        const text = (opt && opt.text ? opt.text : "").toLowerCase();
-        return text.includes("correctiv");
-      }
-      function toggleCorrective(){
-        const sel = document.getElementById("id_order_type");
-        const block = document.getElementById("corrective-section");
-        if(!sel || !block) return;
-        block.style.display = isCorrectiveOption(sel) ? "block" : "none";
-      }
-      document.addEventListener("change", function(e){
-        if(e.target && e.target.id === "id_order_type") toggleCorrective();
-      });
-      document.addEventListener("DOMContentLoaded", function(){
-        toggleCorrective();
-        const addBtn = document.getElementById("add-task-btn");
-        const totalForms = document.getElementById("id_tasks-TOTAL_FORMS");
-        const tableBody = document.querySelector("#tasks-table tbody");
-        const tmpl = document.getElementById("task-empty-form");
-        if(addBtn && totalForms && tableBody && tmpl){
-          addBtn.addEventListener("click", function(){
-            const idx = parseInt(totalForms.value, 10);
-            const newRowHtml = tmpl.innerHTML.replace(/__prefix__/g, idx);
-            tableBody.insertAdjacentHTML('beforeend', newRowHtml);
-            totalForms.value = idx + 1;
-          });
-        }
-      });
-</script>
+<script src="{% static 'workorders/order_full_form.js' %}"></script>
 {% endblock %}

--- a/workorders/tests/manual/test_corrective_section.md
+++ b/workorders/tests/manual/test_corrective_section.md
@@ -1,0 +1,8 @@
+# Prueba manual: Visibilidad del bloque "Solo Correctivo"
+
+1. Ingresar a la creación de una Orden de Trabajo unificada (`/workorders/unified/new/`).
+2. Verificar que el bloque **Solo Correctivo** no se muestre cuando el campo **Tipo de OT** no es Correctivo.
+3. Cambiar el **Tipo de OT** a una opción que contenga la palabra "Correctivo".
+4. Confirmar que el bloque **Solo Correctivo** aparece.
+5. Cambiar nuevamente el **Tipo de OT** a una opción que no sea Correctivo.
+6. Confirmar que el bloque **Solo Correctivo** se oculta.


### PR DESCRIPTION
## Summary
- move work order full form JS logic into static file
- document manual test for the "Solo Correctivo" block

## Testing
- `python manage.py test workorders.tests.test_task_formset`


------
https://chatgpt.com/codex/tasks/task_e_68b5ca1160108322bd2fa578e74d8fdb