### PR TITLE
feat: make work order rate configurable

### DIFF
--- a/project/settings.py
+++ b/project/settings.py
@@ -103,3 +103,6 @@ LOGGING = {
     'handlers': {'console': {'class': 'logging.StreamHandler'}},
     'root': {'handlers': ['console'], 'level': 'INFO'},
 }
+
+# Tarifa por hora para trabajos internos en órdenes de trabajo
+WORKORDER_INTERNAL_RATE = 50000

--- a/workorders/models.py
+++ b/workorders/models.py
@@ -257,7 +257,7 @@ class WorkOrder(models.Model):
             internal=Sum("hours_spent", filter=Q(is_external=False)),
             external=Sum("labor_rate", filter=Q(is_external=True)),
         )
-        internal_rate = 50000  # TODO: parametrizar
+        internal_rate = settings.WORKORDER_INTERNAL_RATE
         self.labor_cost_internal = (labor_costs["internal"] or 0) * internal_rate
         self.labor_cost_external = labor_costs["external"] or 0
 

--- a/workorders/tests/test_internal_rate.py
+++ b/workorders/tests/test_internal_rate.py
@@ -1,0 +1,33 @@
+from decimal import Decimal
+
+from django.test import TestCase, override_settings
+
+from fleet.models import Vehicle
+from workorders.models import WorkOrder, WorkOrderTask
+
+
+class WorkOrderCostCalculationTests(TestCase):
+    def setUp(self):
+        self.vehicle = Vehicle.objects.create(
+            plate="XYZ123",
+            brand="Brand",
+            linea="Line",
+            modelo=2020,
+            vehicle_type=Vehicle.VehicleType.AUTOMOVIL,
+        )
+        self.work_order = WorkOrder.objects.create(
+            vehicle=self.vehicle,
+            description="Test order",
+        )
+
+    @override_settings(WORKORDER_INTERNAL_RATE=20000)
+    def test_recalculate_costs_uses_configured_rate(self):
+        WorkOrderTask.objects.create(
+            work_order=self.work_order,
+            description="Internal task",
+            hours_spent=2,
+            is_external=False,
+        )
+        self.work_order.recalculate_costs()
+        self.work_order.refresh_from_db()
+        self.assertEqual(self.work_order.labor_cost_internal, Decimal("40000"))


### PR DESCRIPTION
## Summary
- configure internal labor rate via `WORKORDER_INTERNAL_RATE`
- use setting instead of hardcoded value when recalculating costs
- add regression test for configurable labor rate

## Testing
- `python manage.py test` *(fails: 'tests' module incorrectly imported from '/workspace/sigma-project/fleet/tests')*
- `python manage.py test workorders.tests.test_internal_rate`


------
https://chatgpt.com/codex/tasks/task_e_68b5d0196ac08322ac2dadff3fd334f7