### PR TITLE
docs: document DumpOnErrorMiddleware

### DIFF
--- a/core/middleware.py
+++ b/core/middleware.py
@@ -1,13 +1,42 @@
-# core/middleware.py
+"""Middleware utilitario para volcar información de errores.
+
+`DumpOnErrorMiddleware` registra en los logs los datos relevantes de la
+solicitud y el *traceback* cuando ocurre una excepción no controlada.
+"""
+
 import logging
 import traceback
 
+
 logger = logging.getLogger(__name__)
 
+
 class DumpOnErrorMiddleware:
+    """Registra detalles de la petición si se produce un error."""
+
     def __init__(self, get_response):
+        """Inicializa el middleware.
+
+        Args:
+            get_response (Callable): Función que procesa la solicitud y
+                devuelve la respuesta.
+        """
+
         self.get_response = get_response
+
     def __call__(self, request):
+        """Procesa la solicitud y captura excepciones.
+
+        Args:
+            request (HttpRequest): La solicitud entrante.
+
+        Returns:
+            HttpResponse: Respuesta generada por la vista.
+
+        Raises:
+            Exception: Propaga la excepción original tras registrarla.
+        """
+
         try:
             return self.get_response(request)
         except Exception:
@@ -18,7 +47,7 @@ class DumpOnErrorMiddleware:
                     request.path,
                     dict(request.POST),
                     {k: v.name for k, v in request.FILES.items()},
-                    traceback.format_exc()
+                    traceback.format_exc(),
                 )
             except Exception:
                 logger.exception("No se pudo volcar el error")


### PR DESCRIPTION
## Summary
- add module and method docstrings for DumpOnErrorMiddleware
- explain parameters and behavior when logging unhandled errors

## Testing
- `python manage.py test` *(fails: ImportError: 'tests' module incorrectly imported from '/workspace/sigma-project/fleet/tests'. Expected '/workspace/sigma-project/fleet'. Is this module globally installed?)*
- `python manage.py test core`

------
https://chatgpt.com/codex/tasks/task_e_68b5d018fbb48322a37de8197946ad19