### PR TITLE
feat(users): add driver and profile APIs

### DIFF
--- a/project/urls.py
+++ b/project/urls.py
@@ -55,6 +55,7 @@ urlpatterns = [
     path('api/fleet/', include('fleet.urls')),
     path('api/workorders/', include('workorders.urls')),
     path('api/inventory/', include('inventory.urls')),
+    path('api/users/', include('users.urls')),
     path('api/auth/login/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
     path('api/auth/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
 ]

--- a/users/README.md
+++ b/users/README.md
@@ -1,0 +1,8 @@
+# Users App
+
+API endpoints for managing user profiles and drivers.
+
+## Routes
+
+- `/api/users/drivers/`: CRUD operations for `Driver` records.
+- `/api/users/profiles/`: CRUD operations for `UserProfile` records.

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -1,0 +1,24 @@
+"""Serializers for the users application."""
+
+from django.contrib.auth.models import User
+from rest_framework import serializers
+
+from .models import Driver, UserProfile
+
+
+class DriverSerializer(serializers.ModelSerializer):
+    """Serializer for Driver objects."""
+
+    class Meta:
+        model = Driver
+        fields = ["id", "full_name", "document_number", "zone", "is_active"]
+
+
+class UserProfileSerializer(serializers.ModelSerializer):
+    """Serializer for UserProfile objects."""
+
+    user = serializers.PrimaryKeyRelatedField(queryset=User.objects.all())
+
+    class Meta:
+        model = UserProfile
+        fields = ["id", "user", "zone"]

--- a/users/urls.py
+++ b/users/urls.py
@@ -1,0 +1,12 @@
+"""URL routes for the users application."""
+
+from django.urls import include, path
+from rest_framework.routers import DefaultRouter
+
+from .views import DriverViewSet, UserProfileViewSet
+
+router = DefaultRouter()
+router.register(r"drivers", DriverViewSet)
+router.register(r"profiles", UserProfileViewSet)
+
+urlpatterns = [path("", include(router.urls))]

--- a/users/views.py
+++ b/users/views.py
@@ -1,5 +1,20 @@
-"""Views for the users application."""
+"""Viewsets for the users application."""
 
-from django.shortcuts import render
+from rest_framework import viewsets
 
-# Create your views here.
+from .models import Driver, UserProfile
+from .serializers import DriverSerializer, UserProfileSerializer
+
+
+class DriverViewSet(viewsets.ModelViewSet):
+    """API endpoint for viewing and editing drivers."""
+
+    queryset = Driver.objects.all()
+    serializer_class = DriverSerializer
+
+
+class UserProfileViewSet(viewsets.ModelViewSet):
+    """API endpoint for viewing and editing user profiles."""
+
+    queryset = UserProfile.objects.select_related("user")
+    serializer_class = UserProfileSerializer


### PR DESCRIPTION
## Summary
- expose Driver and UserProfile via REST viewsets
- add routing for new users API endpoints
- document available users API routes

## Testing
- `python manage.py test users`
- `python manage.py test` *(fails: ImportError: 'tests' module incorrectly imported from '/workspace/sigma-project/fleet/tests')*

------
https://chatgpt.com/codex/tasks/task_e_68b5d0186678832291e64f6ee91ed45c