### PR TITLE
Refactor FuelUploadLog docstring and document fields

### DIFF
--- a/reports/models.py
+++ b/reports/models.py
@@ -5,17 +5,36 @@ from django.conf import settings
 
 
 class FuelUploadLog(models.Model):
-    """
-    Registro de archivos de tanqueos procesados para evitar reprocesos pesados.
-    Se identifica por hash SHA-256 del archivo.
-    """
-    original_filename = models.CharField(max_length=255)
-    sha256 = models.CharField(max_length=64, unique=True)
-    size_bytes = models.BigIntegerField()
-    sheet_name = models.CharField(max_length=100, default="TANQUEOS")
-    rows_processed = models.PositiveIntegerField(default=0)
-    vehicles_updated = models.PositiveIntegerField(default=0)
-    processed_at = models.DateTimeField(auto_now_add=True)
+    """Registro de archivos procesados, identificado por el hash SHA-256 del archivo."""
+    original_filename = models.CharField(
+        max_length=255,
+        help_text="Nombre original del archivo subido.",
+    )
+    sha256 = models.CharField(
+        max_length=64,
+        unique=True,
+        help_text="Hash SHA-256 del archivo procesado.",
+    )
+    size_bytes = models.BigIntegerField(
+        help_text="Tamaño del archivo en bytes.",
+    )
+    sheet_name = models.CharField(
+        max_length=100,
+        default="TANQUEOS",
+        help_text="Nombre de la hoja del archivo procesada.",
+    )
+    rows_processed = models.PositiveIntegerField(
+        default=0,
+        help_text="Número de filas leídas del archivo.",
+    )
+    vehicles_updated = models.PositiveIntegerField(
+        default=0,
+        help_text="Cantidad de vehículos actualizados.",
+    )
+    processed_at = models.DateTimeField(
+        auto_now_add=True,
+        help_text="Fecha y hora de procesamiento.",
+    )
     processed_by = models.ForeignKey(
         settings.AUTH_USER_MODEL,
         on_delete=models.SET_NULL,
@@ -23,6 +42,7 @@ class FuelUploadLog(models.Model):
         blank=True,
         # 👇 nombre único para evitar choque con cualquier otro FuelUploadLog
         related_name="fuel_upload_logs_reports",
+        help_text="Usuario que procesó el archivo.",
     )
 
     class Meta:


### PR DESCRIPTION
## Summary
- Rewrite `FuelUploadLog` docstring as single-line description
- Add `help_text` annotations to model fields

## Testing
- `flake8 reports/models.py` *(fails: command not found)*
- `python manage.py test` *(fails: ImportError: 'tests' module incorrectly imported)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d0170e6c83228e10d15a703bfb7d