### PR TITLE
fix(fleet): constrain vehicle type field

### DIFF
--- a/fleet/models.py
+++ b/fleet/models.py
@@ -36,7 +36,9 @@ class Vehicle(models.Model):
     modelo = models.PositiveIntegerField("Modelo")
     vehicle_type = models.CharField(
         "Tipo de Vehículo",
-
+        max_length=10,
+        choices=VehicleType.choices,
+        help_text="Seleccione el tipo de vehículo",
     )
     fuel_type = models.CharField("Tipo de Combustible", max_length=20, choices=FuelType.choices, default=FuelType.DIESEL)
     status = models.CharField("Estado", max_length=20, choices=VehicleStatus.choices, default=VehicleStatus.ACTIVE)


### PR DESCRIPTION
## Summary
- specify vehicle type max length, options, and help text

## Testing
- `python manage.py makemigrations --check --dry-run`
- `python manage.py test` *(fails: 'tests' module incorrectly imported from '/workspace/sigma-project/fleet/tests')*

------
https://chatgpt.com/codex/tasks/task_e_68b5d7655c308322a5080984ed72cca8