### PR TITLE
Redirect WorkOrder admin to unified interface

### DIFF
--- a/workorders/admin.py
+++ b/workorders/admin.py
@@ -1,5 +1,6 @@
 # workorders/admin.py
 from django.contrib import admin
+from django.shortcuts import redirect
 from .models import (
     WorkOrder,
     WorkOrderNote,
@@ -28,6 +29,9 @@ class WorkOrderAdmin(admin.ModelAdmin):
     list_filter = ("order_type", "status", "priority")
     raw_id_fields = ()  # sin lupas
     inlines = [WorkOrderTaskInline]
+
+    def add_view(self, request, form_url="", extra_context=None):
+        return redirect("workorders_admin_new")
 
 @admin.register(WorkOrderNote)
 class WorkOrderNoteAdmin(admin.ModelAdmin):

--- a/workorders/templates/admin/workorders/workorder/change_form.html
+++ b/workorders/templates/admin/workorders/workorder/change_form.html
@@ -20,10 +20,5 @@
       <p>No hay novedades.</p>
     {% endif %}
   </div>
-  {% else %}
-  <div class="module aligned" style="margin-top:24px;">
-    <p>Para crear una nueva OT usa la interfaz unificada:</p>
-    <p><a class="button" href="{% url 'workorders_admin_new' %}">Nueva OT</a></p>
-  </div>
   {% endif %}
 {% endblock %}

--- a/workorders/templates/admin/workorders/workorder/change_list.html
+++ b/workorders/templates/admin/workorders/workorder/change_list.html
@@ -1,0 +1,8 @@
+{% extends "admin/change_list.html" %}
+
+{% block object-tools-items %}
+{% if has_add_permission %}
+<li><a href="{% url 'workorders_admin_new' %}" class="addlink">Nueva OT</a></li>
+{% endif %}
+{% endblock %}
+


### PR DESCRIPTION
## Summary
- Redirect WorkOrder admin add view to the unified creation interface
- Add "Nueva OT" button on work order admin list
- Remove in-form link for creating new work orders

## Testing
- `SECRET_KEY=test python manage.py test workorders` (fails: ImportError: 'tests' module incorrectly imported)

------
https://chatgpt.com/codex/tasks/task_e_68b5dd29b0548322bde2be5fb1e78d15