### PR TITLE
Use unified work order form for all types

### DIFF
--- a/workorders/forms.py
+++ b/workorders/forms.py
@@ -191,10 +191,6 @@ class WorkOrderUnifiedForm(forms.ModelForm):
             if _field_exists(WorkOrder, "severity"):
                 instance.severity = self.cleaned_data.get('severity') or getattr(instance, "severity", None)
             instance.save()
-        else:
-            if _field_exists(WorkOrder, "pre_diagnosis") and getattr(instance, "pre_diagnosis", None):
-                instance.pre_diagnosis = ""
-                instance.save(update_fields=['pre_diagnosis'])
 
         # Guardar campos datetime reales, si existen
         touched_dt = False
@@ -217,37 +213,6 @@ class WorkOrderUnifiedForm(forms.ModelForm):
             instance.save()
 
         return instance
-
-# ---------- Formularios específicos ----------
-class PreventiveWorkOrderForm(WorkOrderUnifiedForm):
-    """Formulario para órdenes preventivas. Oculta campos exclusivos de las correctivas."""
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        # Se fuerza el tipo y se oculta el campo correspondiente
-        self.fields.pop('order_type', None)
-        # Eliminar campos relacionados al flujo correctivo
-        for fname in ("pre_diagnosis", "failure_origin", "severity", "probable_causes"):
-            self.fields.pop(fname, None)
-
-    def save(self, user=None, commit=True):
-        # Asignar automáticamente el tipo preventivo antes de guardar
-        self.cleaned_data['order_type'] = WorkOrder.OrderType.PREVENTIVE
-        return super().save(user=user, commit=commit)
-
-
-class CorrectiveWorkOrderForm(WorkOrderUnifiedForm):
-    """Formulario para órdenes correctivas (incluye diagnóstico, severidad y causas)."""
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        # Se fuerza el tipo y se oculta el campo correspondiente
-        self.fields.pop('order_type', None)
-
-    def save(self, user=None, commit=True):
-        # Asignar automáticamente el tipo correctivo antes de guardar
-        self.cleaned_data['order_type'] = WorkOrder.OrderType.CORRECTIVE
-        return super().save(user=user, commit=commit)
-
 # ---------- Formset de TAREAS (categoría/subcategoría) ----------
 TaskFormSet = inlineformset_factory(
     WorkOrder, WorkOrderTask,

--- a/workorders/templates/admin/workorders/order_full_form.html
+++ b/workorders/templates/admin/workorders/order_full_form.html
@@ -39,8 +39,7 @@
       <!-- Datos base -->
       <div class="card grid cols-3">
         <div>
-          <label>Tipo de OT</label>
-          <input type="text" value="{{ order_type_label }}" disabled>
+          <label>Tipo de OT</label>{{ form.order_type }}
         </div>
         <div>
           <label>Vehículo *</label>{{ form.vehicle }}
@@ -124,9 +123,8 @@
       </div>
       {% endif %}
 
-      {% if show_corrective %}
       <!-- Sección Correctivo -->
-      <div class="card" id="corrective-section">
+      <div class="card" id="corrective-section"{% if not show_corrective %} style="display:none"{% endif %}>
         <h2 class="section-title"><span class="badge">Solo Correctivo</span> Diagnóstico</h2>
         <div class="grid cols-3">
           <div><label>Severidad</label>{{ form.severity }}</div>
@@ -135,7 +133,6 @@
           <div style="grid-column:1/-1"><label>Causas probables</label>{{ form.probable_causes }}</div>
         </div>
       </div>
-      {% endif %}
 
       <!-- Tareas -->
       <div class="card">
@@ -218,6 +215,19 @@
     </form>
   </div>
 
-  
+  <script>
+    function toggleCorrective(){
+      var sel=document.getElementById('id_order_type');
+      var section=document.getElementById('corrective-section');
+      if(!sel||!section)return;
+      section.style.display=sel.value==='CORRECTIVE'?'block':'none';
+    }
+    document.addEventListener('DOMContentLoaded',function(){
+      toggleCorrective();
+      var sel=document.getElementById('id_order_type');
+      if(sel)sel.addEventListener('change',toggleCorrective);
+    });
+  </script>
+
 </body>
 </html>

--- a/workorders/templates/workorders/order_full_form.html
+++ b/workorders/templates/workorders/order_full_form.html
@@ -26,8 +26,7 @@
       <!-- Datos base -->
       <div class="card grid cols-3">
         <div>
-          <label>Tipo de OT</label>
-          <input type="text" value="{{ order_type_label }}" disabled>
+          <label>Tipo de OT</label>{{ form.order_type }}
         </div>
         <div>
           <label>Vehículo *</label>{{ form.vehicle }}
@@ -121,9 +120,8 @@
       </div>
       {% endif %}
 
-      {% if show_corrective %}
       <!-- Sección Correctivo -->
-      <div class="card" id="corrective-section">
+      <div class="card" id="corrective-section"{% if not show_corrective %} style="display:none"{% endif %}>
         <h2 class="section-title"><span class="badge">Solo Correctivo</span> Diagnóstico</h2>
         <div class="grid cols-3">
           <div><label>Severidad</label>{{ form.severity }}</div>
@@ -132,7 +130,6 @@
           <div style="grid-column:1/-1"><label>Causas probables</label>{{ form.probable_causes }}</div>
         </div>
       </div>
-      {% endif %}
 
       <!-- Tareas -->
       <div class="card">
@@ -235,5 +232,17 @@
 {% endblock %}
 
 {% block extrahead %}
-
+  <script>
+    function toggleCorrective() {
+      var sel = document.getElementById('id_order_type');
+      var section = document.getElementById('corrective-section');
+      if (!sel || !section) return;
+      section.style.display = sel.value === 'CORRECTIVE' ? 'block' : 'none';
+    }
+    document.addEventListener('DOMContentLoaded', function() {
+      toggleCorrective();
+      var sel = document.getElementById('id_order_type');
+      if (sel) sel.addEventListener('change', toggleCorrective);
+    });
+  </script>
 {% endblock %}

--- a/workorders/tests/test_task_formset.py
+++ b/workorders/tests/test_task_formset.py
@@ -23,6 +23,7 @@ class TaskFormSetTests(TestCase):
     def test_can_add_multiple_tasks(self):
         url = reverse("workorders_unified_new") + "?type=corrective"
         data = {
+            "order_type": WorkOrder.OrderType.CORRECTIVE,
             "vehicle": self.vehicle.id,
             "status": WorkOrder.OrderStatus.SCHEDULED,
             "priority": WorkOrder.Priority.MEDIUM,


### PR DESCRIPTION
## Summary
- Switch workorder views to always use `WorkOrderUnifiedForm` and compute corrective section dynamically
- Simplify forms by removing preventive/corrective subclasses and preserving corrective data regardless of type
- Show and hide corrective fields in order form templates based on selected order type

## Testing
- `SECRET_KEY=test python manage.py test workorders.tests`

------
https://chatgpt.com/codex/tasks/task_e_68b5e1d104208322864b93abbbba387e