### PR TITLE
Add Select2 search for work order fields

### DIFF
--- a/fleet/views.py
+++ b/fleet/views.py
@@ -1,6 +1,6 @@
 """Viewsets for the fleet application."""
 
-from rest_framework import viewsets, status
+from rest_framework import viewsets, status, filters
 from rest_framework.response import Response
 from rest_framework.exceptions import ValidationError
 from .models import Vehicle
@@ -12,6 +12,8 @@ class VehicleViewSet(viewsets.ModelViewSet):
 
     queryset = Vehicle.objects.all()
     serializer_class = VehicleSerializer
+    filter_backends = [filters.SearchFilter]
+    search_fields = ["plate", "vin", "brand", "linea"]
 
     def _handle_request(self, request, partial=False, instance=None):
         serializer = self.get_serializer(

--- a/users/views.py
+++ b/users/views.py
@@ -1,6 +1,6 @@
 """Viewsets for the users application."""
 
-from rest_framework import viewsets
+from rest_framework import viewsets, filters
 
 from .models import Driver, UserProfile
 from .serializers import DriverSerializer, UserProfileSerializer
@@ -11,6 +11,8 @@ class DriverViewSet(viewsets.ModelViewSet):
 
     queryset = Driver.objects.all()
     serializer_class = DriverSerializer
+    filter_backends = [filters.SearchFilter]
+    search_fields = ["full_name", "document_number"]
 
 
 class UserProfileViewSet(viewsets.ModelViewSet):

--- a/workorders/forms.py
+++ b/workorders/forms.py
@@ -3,6 +3,7 @@ from django import forms
 from django.forms import inlineformset_factory
 from django.core.exceptions import FieldDoesNotExist
 from django.apps import apps
+from django.urls import reverse_lazy
 
 from .models import (
     WorkOrder, WorkOrderTask, WorkOrderNote, ProbableCause
@@ -46,7 +47,13 @@ class WorkOrderUnifiedForm(forms.ModelForm):
         driver = forms.ModelChoiceField(
             label="Conductor responsable",
             queryset=getattr(Driver, "objects", Driver) if hasattr(Driver, "objects") else [],
-            required=False
+            required=False,
+            widget=forms.Select(
+                attrs={
+                    "class": "select2-ajax",
+                    "data-url": reverse_lazy("driver-list"),
+                }
+            ),
         )
         driver_responsibility = forms.DecimalField(
             label="Responsabilidad del conductor (%)",
@@ -92,6 +99,9 @@ class WorkOrderUnifiedForm(forms.ModelForm):
             # Campos de costo general si tu modelo los trae (se añaden abajo dinámicamente)
         ]
         widgets = {
+            'vehicle': forms.Select(
+                attrs={'class': 'select2-ajax', 'data-url': reverse_lazy('vehicle-list')}
+            ),
             'scheduled_start': forms.DateTimeInput(attrs={'type': 'datetime-local'}),
             'scheduled_end': forms.DateTimeInput(attrs={'type': 'datetime-local'}),
             'description': forms.Textarea(attrs={'rows':3}),
@@ -217,6 +227,14 @@ class WorkOrderUnifiedForm(forms.ModelForm):
 TaskFormSet = inlineformset_factory(
     WorkOrder, WorkOrderTask,
     fields=['category','subcategory','description','hours_spent','is_external','labor_rate'],
+    widgets={
+        'category': forms.Select(attrs={
+            'class': 'select2-ajax', 'data-url': reverse_lazy('category-list')
+        }),
+        'subcategory': forms.Select(attrs={
+            'class': 'select2-ajax', 'data-url': reverse_lazy('subcategory-list')
+        }),
+    },
     extra=1, can_delete=True
 )
 

--- a/workorders/serializers.py
+++ b/workorders/serializers.py
@@ -1,7 +1,14 @@
 """Serializers for work order related models."""
 
 from rest_framework import serializers
-from .models import WorkOrder, MaintenancePlan, WorkOrderTask, WorkOrderPart
+from .models import (
+    WorkOrder,
+    MaintenancePlan,
+    WorkOrderTask,
+    WorkOrderPart,
+    MaintenanceCategory,
+    MaintenanceSubcategory,
+)
 
 
 class WorkOrderTaskSerializer(serializers.ModelSerializer):
@@ -36,5 +43,21 @@ class MaintenancePlanSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = MaintenancePlan
+        fields = "__all__"
+
+
+class MaintenanceCategorySerializer(serializers.ModelSerializer):
+    """Serializer for maintenance categories."""
+
+    class Meta:
+        model = MaintenanceCategory
+        fields = "__all__"
+
+
+class MaintenanceSubcategorySerializer(serializers.ModelSerializer):
+    """Serializer for maintenance subcategories."""
+
+    class Meta:
+        model = MaintenanceSubcategory
         fields = "__all__"
 

--- a/workorders/static/workorders/order_full_form.css
+++ b/workorders/static/workorders/order_full_form.css
@@ -39,3 +39,8 @@
     color: var(--body-quiet-color);
 }
 
+.search-icon {
+    cursor: pointer;
+    margin-left: 4px;
+}
+

--- a/workorders/templates/workorders/order_full_form.html
+++ b/workorders/templates/workorders/order_full_form.html
@@ -5,6 +5,7 @@
 
 {% block extrastyle %}
   {{ block.super }}
+  <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0/dist/css/select2.min.css" rel="stylesheet" />
   <link rel="stylesheet" href="{% static 'workorders/order_full_form.css' %}">
 {% endblock %}
 
@@ -29,7 +30,7 @@
           <label>Tipo de OT</label>{{ form.order_type }}
         </div>
         <div>
-          <label>Vehículo *</label>{{ form.vehicle }}
+          <label>Vehículo *</label>{{ form.vehicle }}<span class="search-icon">🔍</span>
           {% if qc_vehicle %}
           <div class="qc">
             <form method="post">
@@ -95,7 +96,7 @@
       {% if form.fields.driver %}
       <div class="card grid cols-2">
         <div>
-          <label>Conductor responsable</label>{{ form.driver }}
+          <label>Conductor responsable</label>{{ form.driver }}<span class="search-icon">🔍</span>
           {% if qc_driver %}
           <div class="qc">
             <form method="post">
@@ -174,8 +175,8 @@
         <tbody>
           {% for f in task_fs %}
           <tr>
-            <td>{{ f.category }}</td>
-            <td>{{ f.subcategory }}</td>
+            <td>{{ f.category }}<span class="search-icon">🔍</span></td>
+            <td>{{ f.subcategory }}<span class="search-icon">🔍</span></td>
             <td>{{ f.description }}</td>
             <td>{{ f.hours_spent }}</td>
             <td>{{ f.is_external }}</td>
@@ -190,8 +191,8 @@
         </div>
         <template id="task-empty-form">
           <tr>
-            <td>{{ task_fs.empty_form.category }}</td>
-            <td>{{ task_fs.empty_form.subcategory }}</td>
+            <td>{{ task_fs.empty_form.category }}<span class="search-icon">🔍</span></td>
+            <td>{{ task_fs.empty_form.subcategory }}<span class="search-icon">🔍</span></td>
             <td>{{ task_fs.empty_form.description }}</td>
             <td>{{ task_fs.empty_form.hours_spent }}</td>
             <td>{{ task_fs.empty_form.is_external }}</td>
@@ -232,17 +233,66 @@
 {% endblock %}
 
 {% block extrahead %}
+  {{ block.super }}
+  <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0/dist/js/select2.min.js"></script>
   <script>
-    function toggleCorrective() {
-      var sel = document.getElementById('id_order_type');
-      var section = document.getElementById('corrective-section');
-      if (!sel || !section) return;
-      section.style.display = sel.value === 'CORRECTIVE' ? 'block' : 'none';
-    }
-    document.addEventListener('DOMContentLoaded', function() {
-      toggleCorrective();
-      var sel = document.getElementById('id_order_type');
-      if (sel) sel.addEventListener('change', toggleCorrective);
-    });
+    (function($) {
+      function toggleCorrective() {
+        var sel = $('#id_order_type');
+        var section = $('#corrective-section');
+        if (!sel.length || !section.length) return;
+        section.toggle(sel.val() === 'CORRECTIVE');
+      }
+
+      function initSelect($el) {
+        var url = $el.data('url');
+        $el.select2({
+          ajax: {
+            url: url,
+            dataType: 'json',
+            delay: 250,
+            data: function(params) { return { search: params.term }; },
+            processResults: function(data) {
+              var results = data.results || data;
+              return {
+                results: results.map(function(obj) {
+                  var text = obj.plate || obj.full_name || obj.name;
+                  return { id: obj.id, text: text };
+                })
+              };
+            }
+          },
+          width: 'style'
+        });
+        var icon = $el.next('.search-icon');
+        if (icon.length) {
+          icon.on('click', function() { $el.select2('open'); });
+        }
+      }
+
+      function initAll(ctx) {
+        $(ctx).find('select.select2-ajax').each(function() {
+          initSelect($(this));
+        });
+      }
+
+      $(function() {
+        toggleCorrective();
+        $('#id_order_type').on('change', toggleCorrective);
+
+        initAll(document);
+
+        $('#add-task-btn').on('click', function() {
+          var totalForms = $('#id_tasks-TOTAL_FORMS');
+          var tableBody = $('#tasks-table tbody');
+          var tmpl = $('#task-empty-form').html();
+          var idx = parseInt(totalForms.val(), 10);
+          tableBody.append(tmpl.replace(/__prefix__/g, idx));
+          totalForms.val(idx + 1);
+          var newRow = tableBody.find('tr').last();
+          initAll(newRow);
+        });
+      });
+    })(django.jQuery);
   </script>
 {% endblock %}

--- a/workorders/urls.py
+++ b/workorders/urls.py
@@ -7,6 +7,8 @@ from .views import (
     MaintenancePlanViewSet,
     WorkOrderTaskViewSet,
     WorkOrderPartViewSet,
+    MaintenanceCategoryViewSet,
+    MaintenanceSubcategoryViewSet,
     workorder_unified,
     new_preventive, new_corrective, edit_tasks,
     schedule_view,
@@ -30,5 +32,7 @@ router.register(r"workorders", WorkOrderViewSet)
 router.register(r"plans", MaintenancePlanViewSet)
 router.register(r"tasks", WorkOrderTaskViewSet)
 router.register(r"parts", WorkOrderPartViewSet)
+router.register(r"categories", MaintenanceCategoryViewSet, basename="category")
+router.register(r"subcategories", MaintenanceSubcategoryViewSet, basename="subcategory")
 
 urlpatterns += [ path("", include(router.urls)) ]

--- a/workorders/views.py
+++ b/workorders/views.py
@@ -7,14 +7,23 @@ from django.contrib import messages
 from django.contrib.admin.views.decorators import staff_member_required
 from django.views.decorators.http import require_http_methods
 
-from rest_framework import viewsets
+from rest_framework import viewsets, filters
 
-from .models import WorkOrder, MaintenancePlan, WorkOrderTask, WorkOrderPart
+from .models import (
+    WorkOrder,
+    MaintenancePlan,
+    WorkOrderTask,
+    WorkOrderPart,
+    MaintenanceCategory,
+    MaintenanceSubcategory,
+)
 from .serializers import (
     WorkOrderSerializer,
     MaintenancePlanSerializer,
     WorkOrderTaskSerializer,
     WorkOrderPartSerializer,
+    MaintenanceCategorySerializer,
+    MaintenanceSubcategorySerializer,
 )
 from .forms import (
     WorkOrderUnifiedForm, TaskFormSet,
@@ -40,6 +49,20 @@ class WorkOrderPartViewSet(viewsets.ModelViewSet):
 class MaintenancePlanViewSet(viewsets.ModelViewSet):
     queryset = MaintenancePlan.objects.all()
     serializer_class = MaintenancePlanSerializer
+
+
+class MaintenanceCategoryViewSet(viewsets.ModelViewSet):
+    queryset = MaintenanceCategory.objects.all()
+    serializer_class = MaintenanceCategorySerializer
+    filter_backends = [filters.SearchFilter]
+    search_fields = ["name"]
+
+
+class MaintenanceSubcategoryViewSet(viewsets.ModelViewSet):
+    queryset = MaintenanceSubcategory.objects.select_related("category")
+    serializer_class = MaintenanceSubcategorySerializer
+    filter_backends = [filters.SearchFilter]
+    search_fields = ["name", "category__name"]
 
 
 # ========= VISTA UNIFICADA =========


### PR DESCRIPTION
## Summary
- enable Select2-based AJAX search for vehicles, drivers, categories and subcategories in work order forms
- include Select2 assets and search icons in full work order template
- expose API endpoints with search capabilities for vehicles, drivers, categories and subcategories

## Testing
- `SECRET_KEY=dummy DJANGO_SETTINGS_MODULE=project.settings.dev python manage.py test fleet.tests workorders.tests`


------
https://chatgpt.com/codex/tasks/task_e_68b5e7158ad88322ac3ebc10bcd53ebf