### PR TITLE
Listar catálogo de mantenimiento en formulario de OT

### DIFF
--- a/workorders/forms.py
+++ b/workorders/forms.py
@@ -25,8 +25,14 @@ def _model_or_none(app_label: str, model_name: str):
 # Intenta resolver modelos externos (si no existen, ocultamos sus secciones)
 Driver = _model_or_none("users", "Driver")
 Vehicle = _model_or_none("fleet", "Vehicle")
-TaskCategory = _model_or_none("workorders", "TaskCategory")
-TaskSubcategory = _model_or_none("workorders", "TaskSubcategory")
+TaskCategory = (
+    _model_or_none("workorders", "TaskCategory")
+    or _model_or_none("workorders", "MaintenanceCategory")
+)
+TaskSubcategory = (
+    _model_or_none("workorders", "TaskSubcategory")
+    or _model_or_none("workorders", "MaintenanceSubcategory")
+)
 WorkOrderDriver = _model_or_none("workorders", "WorkOrderDriver")
 
 # Choices seguros por si el modelo no define enums

--- a/workorders/templates/admin/workorders/order_full_form.html
+++ b/workorders/templates/admin/workorders/order_full_form.html
@@ -170,6 +170,40 @@
           {% endif %}
         </div>
 
+        {% if categories %}
+        <div class="catalog" style="margin-bottom:10px;">
+          <h3>Catálogo existente</h3>
+          <ul>
+            {% for cat in categories %}
+            <li>
+              {{ cat.name }}
+              {% if perms.workorders.change_maintenancecategory %}
+                <a class="link" href="{% url 'admin:workorders_maintenancecategory_change' cat.id %}">Editar</a>
+              {% endif %}
+              {% if perms.workorders.delete_maintenancecategory %}
+                <a class="link" href="{% url 'admin:workorders_maintenancecategory_delete' cat.id %}">Eliminar</a>
+              {% endif %}
+              {% if cat.subcategories.all %}
+              <ul>
+                {% for sub in cat.subcategories.all %}
+                <li>
+                  {{ sub.name }}
+                  {% if perms.workorders.change_maintenancesubcategory %}
+                    <a class="link" href="{% url 'admin:workorders_maintenancesubcategory_change' sub.id %}">Editar</a>
+                  {% endif %}
+                  {% if perms.workorders.delete_maintenancesubcategory %}
+                    <a class="link" href="{% url 'admin:workorders_maintenancesubcategory_delete' sub.id %}">Eliminar</a>
+                  {% endif %}
+                </li>
+                {% endfor %}
+              </ul>
+              {% endif %}
+            </li>
+            {% endfor %}
+          </ul>
+        </div>
+        {% endif %}
+
         {{ task_fs.management_form }}
         <table>
           <thead>

--- a/workorders/templates/workorders/order_full_form.html
+++ b/workorders/templates/workorders/order_full_form.html
@@ -144,32 +144,66 @@
             <input type="text" name="name" placeholder="Nueva categoría" required>
             <button class="button" type="submit">Crear categoría</button>
           </form>
-          {% endif %}
-          {% if qc_subcategory %}
-          <form method="post">
-            {% csrf_token %}
-            <input type="hidden" name="qc_target" value="subcategory">
-            <input type="text" name="name" placeholder="Nueva subcategoría" required>
-              {% if 'category' in qc_subcategory.fields %}
-                <select name="category" required>
-                  {% for f in task_fs.forms|slice:":1" %}
-                    {% if f.fields.category.choices %}
-                      {% for val,txt in f.fields.category.choices %}
-                        {% if val %}<option value="{{ val }}">{{ txt }}</option>{% endif %}
-                      {% endfor %}
-                    {% endif %}
-                  {% endfor %}
-                </select>
-              {% endif %}
-              <button class="button" type="submit">Crear subcategoría</button>
-            </form>
             {% endif %}
-          </div>
+            {% if qc_subcategory %}
+            <form method="post">
+              {% csrf_token %}
+              <input type="hidden" name="qc_target" value="subcategory">
+              <input type="text" name="name" placeholder="Nueva subcategoría" required>
+                {% if 'category' in qc_subcategory.fields %}
+                  <select name="category" required>
+                    {% for f in task_fs.forms|slice:":1" %}
+                      {% if f.fields.category.choices %}
+                        {% for val,txt in f.fields.category.choices %}
+                          {% if val %}<option value="{{ val }}">{{ txt }}</option>{% endif %}
+                        {% endfor %}
+                      {% endif %}
+                    {% endfor %}
+                  </select>
+                {% endif %}
+                <button class="button" type="submit">Crear subcategoría</button>
+              </form>
+              {% endif %}
+            </div>
 
-          {{ task_fs.management_form }}
-          <table id="tasks-table">
-          <thead>
-            <tr><th>Categoría</th><th>Subcategoría</th><th>Descripción</th><th>Horas</th><th>Tercero</th><th>Tarifa</th><th>Eliminar</th></tr>
+            {% if categories %}
+            <div class="catalog" style="margin-bottom:10px;">
+              <h3>Catálogo existente</h3>
+              <ul>
+                {% for cat in categories %}
+                <li>
+                  {{ cat.name }}
+                  {% if perms.workorders.change_maintenancecategory %}
+                    <a href="{% url 'admin:workorders_maintenancecategory_change' cat.id %}">Editar</a>
+                  {% endif %}
+                  {% if perms.workorders.delete_maintenancecategory %}
+                    <a href="{% url 'admin:workorders_maintenancecategory_delete' cat.id %}">Eliminar</a>
+                  {% endif %}
+                  {% if cat.subcategories.all %}
+                  <ul>
+                    {% for sub in cat.subcategories.all %}
+                    <li>
+                      {{ sub.name }}
+                      {% if perms.workorders.change_maintenancesubcategory %}
+                        <a href="{% url 'admin:workorders_maintenancesubcategory_change' sub.id %}">Editar</a>
+                      {% endif %}
+                      {% if perms.workorders.delete_maintenancesubcategory %}
+                        <a href="{% url 'admin:workorders_maintenancesubcategory_delete' sub.id %}">Eliminar</a>
+                      {% endif %}
+                    </li>
+                    {% endfor %}
+                  </ul>
+                  {% endif %}
+                </li>
+                {% endfor %}
+              </ul>
+            </div>
+            {% endif %}
+
+            {{ task_fs.management_form }}
+            <table id="tasks-table">
+            <thead>
+              <tr><th>Categoría</th><th>Subcategoría</th><th>Descripción</th><th>Horas</th><th>Tercero</th><th>Tarifa</th><th>Eliminar</th></tr>
           </thead>
         <tbody>
           {% for f in task_fs %}

--- a/workorders/views.py
+++ b/workorders/views.py
@@ -9,7 +9,13 @@ from django.views.decorators.http import require_http_methods
 
 from rest_framework import viewsets
 
-from .models import WorkOrder, MaintenancePlan, WorkOrderTask, WorkOrderPart
+from .models import (
+    WorkOrder,
+    MaintenancePlan,
+    WorkOrderTask,
+    WorkOrderPart,
+    MaintenanceCategory,
+)
 from .serializers import (
     WorkOrderSerializer,
     MaintenancePlanSerializer,
@@ -165,6 +171,7 @@ def workorder_unified(request, pk=None):
         )
         if plan:
             manual = plan.manual
+    categories = MaintenanceCategory.objects.prefetch_related("subcategories").all()
 
     return render(request, "workorders/order_full_form.html", {
         "form": form,
@@ -175,6 +182,7 @@ def workorder_unified(request, pk=None):
         "title": ("Editar OT" if ot else "Nueva OT"),
         "manual": manual,
         "show_corrective": show_corrective,
+        "categories": categories,
         # Quick-create forms (si existen)
         "qc_vehicle": QuickCreateVehicleForm() if QuickCreateVehicleForm._meta.fields else None,
         "qc_driver": QuickCreateDriverForm() if QuickCreateDriverForm._meta.fields else None,


### PR DESCRIPTION
## Summary
- Exponer categorías y subcategorías de mantenimiento en `workorder_unified`
- Mostrar catálogo existente con enlaces de edición/eliminación en el formulario de OT
- Ajustar formularios rápidos para detectar modelos de mantenimiento

## Testing
- `SECRET_KEY=dummy python manage.py test` *(fails: The SECRET_KEY setting must not be empty)*
- `SECRET_KEY=dummy python manage.py test workorders.tests.test_task_formset`


------
https://chatgpt.com/codex/tasks/task_e_68b5e71a80188322ba2a979bfd4cc500