### PR TITLE
Separar quick create de formulario principal de OT

### DIFF
--- a/workorders/admin_urls.py
+++ b/workorders/admin_urls.py
@@ -1,8 +1,9 @@
 # workorders/admin_urls.py
 from django.urls import path
-from .views import workorder_unified
+from .views import workorder_unified, quick_create
 
 urlpatterns = [
     path("workorder/new/", workorder_unified, name="workorders_admin_new"),
     path("workorder/<int:pk>/edit/", workorder_unified, name="workorders_admin_edit"),
+    path("workorder/qc/<str:target>/", quick_create, name="workorders_admin_qc"),
 ]

--- a/workorders/templates/workorders/order_full_form.html
+++ b/workorders/templates/workorders/order_full_form.html
@@ -18,11 +18,28 @@
 
 {% block content %}
   <div class="order-form">
-    <h1>{{ title }}{% if ot %} — OT #{{ ot.id }} — {{ ot.vehicle }}{% endif %}</h1>
-    <p class="muted">Orden de Trabajo unificada: conductor, fechas, (correctivo) diagnóstico, tareas y novedades. Sin evidencias.</p>
+      <h1>{{ title }}{% if ot %} — OT #{{ ot.id }} — {{ ot.vehicle }}{% endif %}</h1>
+      <p class="muted">Orden de Trabajo unificada: conductor, fechas, (correctivo) diagnóstico, tareas y novedades. Sin evidencias.</p>
 
-    <form method="post">
-      {% csrf_token %}
+      {% if qc_vehicle or qc_driver or qc_category or qc_subcategory %}
+      <div style="display:none;">
+        {% if qc_vehicle %}
+        <form id="qc_vehicle_form" method="post" action="{% url qc_url_name 'vehicle' %}">{% csrf_token %}</form>
+        {% endif %}
+        {% if qc_driver %}
+        <form id="qc_driver_form" method="post" action="{% url qc_url_name 'driver' %}">{% csrf_token %}</form>
+        {% endif %}
+        {% if qc_category %}
+        <form id="qc_category_form" method="post" action="{% url qc_url_name 'category' %}">{% csrf_token %}</form>
+        {% endif %}
+        {% if qc_subcategory %}
+        <form id="qc_subcategory_form" method="post" action="{% url qc_url_name 'subcategory' %}">{% csrf_token %}</form>
+        {% endif %}
+      </div>
+      {% endif %}
+
+      <form method="post">
+        {% csrf_token %}
 
       <!-- Datos base -->
       <fieldset class="module aligned">
@@ -32,12 +49,8 @@
         </div>
           {% if qc_vehicle %}
           <div class="qc">
-            <form method="post">
-              {% csrf_token %}
-              <input type="hidden" name="qc_target" value="vehicle">
-              <input type="text" name="plate" placeholder="Placa nueva" required>
-              <button class="button" type="submit">Crear placa</button>
-            </form>
+              <input form="qc_vehicle_form" type="text" name="plate" placeholder="Placa nueva" required>
+              <button class="button" form="qc_vehicle_form" type="submit">Crear placa</button>
           </div>
           {% endif %}
         </div>
@@ -94,23 +107,19 @@
       <!-- Conductor -->
       {% if form.fields.driver %}
 
-          {% if qc_driver %}
-          <div class="qc">
-            <form method="post">
-              {% csrf_token %}
-              <input type="hidden" name="qc_target" value="driver">
+            {% if qc_driver %}
+            <div class="qc">
               {% if 'full_name' in qc_driver.fields %}
-                <input type="text" name="full_name" placeholder="Nombre del conductor" required>
+                <input form="qc_driver_form" type="text" name="full_name" placeholder="Nombre del conductor" required>
               {% elif 'name' in qc_driver.fields %}
-                <input type="text" name="name" placeholder="Nombre del conductor" required>
+                <input form="qc_driver_form" type="text" name="name" placeholder="Nombre del conductor" required>
               {% endif %}
               {% if 'is_active' in qc_driver.fields %}
-                <label><input type="checkbox" name="is_active" checked> Activo</label>
+                <label><input form="qc_driver_form" type="checkbox" name="is_active" checked> Activo</label>
               {% endif %}
-              <button class="button" type="submit">Crear conductor</button>
-            </form>
-          </div>
-          {% endif %}
+              <button class="button" form="qc_driver_form" type="submit">Crear conductor</button>
+            </div>
+            {% endif %}
         </div>
         <div class="form-row">
           <label>% responsabilidad</label>{{ form.driver_responsibility }}
@@ -132,33 +141,29 @@
         <h2 class="section-title">Tareas (categoría / subcategoría)</h2>
 
         <!-- Quick create de categorías/subcategorías -->
-        <div class="qc" style="margin-bottom:10px;">
-          {% if qc_category %}
-          <form method="post">
-            {% csrf_token %}
-            <input type="hidden" name="qc_target" value="category">
-            <input type="text" name="name" placeholder="Nueva categoría" required>
-            <button class="button" type="submit">Crear categoría</button>
-          </form>
-          {% endif %}
-          {% if qc_subcategory %}
-          <form method="post">
-            {% csrf_token %}
-            <input type="hidden" name="qc_target" value="subcategory">
-            <input type="text" name="name" placeholder="Nueva subcategoría" required>
-              {% if 'category' in qc_subcategory.fields %}
-                <select name="category" required>
-                  {% for f in task_fs.forms|slice:":1" %}
-                    {% if f.fields.category.choices %}
-                      {% for val,txt in f.fields.category.choices %}
-                        {% if val %}<option value="{{ val }}">{{ txt }}</option>{% endif %}
-                      {% endfor %}
-                    {% endif %}
-                  {% endfor %}
-                </select>
-              {% endif %}
-              <button class="button" type="submit">Crear subcategoría</button>
-            </form>
+          <div class="qc" style="margin-bottom:10px;">
+            {% if qc_category %}
+            <div>
+              <input form="qc_category_form" type="text" name="name" placeholder="Nueva categoría" required>
+              <button class="button" form="qc_category_form" type="submit">Crear categoría</button>
+            </div>
+            {% endif %}
+            {% if qc_subcategory %}
+            <div>
+              <input form="qc_subcategory_form" type="text" name="name" placeholder="Nueva subcategoría" required>
+                {% if 'category' in qc_subcategory.fields %}
+                  <select form="qc_subcategory_form" name="category" required>
+                    {% for f in task_fs.forms|slice:":1" %}
+                      {% if f.fields.category.choices %}
+                        {% for val,txt in f.fields.category.choices %}
+                          {% if val %}<option value="{{ val }}">{{ txt }}</option>{% endif %}
+                        {% endfor %}
+                      {% endif %}
+                    {% endfor %}
+                  </select>
+                {% endif %}
+                <button class="button" form="qc_subcategory_form" type="submit">Crear subcategoría</button>
+            </div>
             {% endif %}
           </div>
 

--- a/workorders/urls.py
+++ b/workorders/urls.py
@@ -10,12 +10,14 @@ from .views import (
     MaintenanceCategoryViewSet,
     MaintenanceSubcategoryViewSet,
     workorder_unified,
+    quick_create,
     new_preventive, new_corrective, edit_tasks,
     schedule_view,
 )
 
 # --------- HTML UNIFICADO (no admin; compatibilidad) ---------
 urlpatterns = [
+    path("workorders/qc/<str:target>/", quick_create, name="workorders_quick_create"),
     path("workorders/new/", workorder_unified, name="workorders_unified_new"),
     path("workorders/<int:pk>/edit/", workorder_unified, name="workorders_unified_edit"),
 


### PR DESCRIPTION
## Summary
- Manejo de quick create mediante vista dedicada y rutas propias
- Formularios rápidos externos con tokens CSRF independientes
- Ajuste de URLs para distinguir origen de la petición

## Testing
- `python manage.py test` *(falla: The SECRET_KEY setting must not be empty.)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ec852e6c83229e2e2b4f2f40ade1