### PR TITLE
Make workorder form usable outside admin

### DIFF
--- a/workorders/templates/workorders/order_full_form.html
+++ b/workorders/templates/workorders/order_full_form.html
@@ -1,4 +1,4 @@
-{% extends "admin/base_site.html" %}
+{% extends use_admin_base|yesno:"admin/base_site.html,base.html" %}
 {% load static %}
 
 {% block title %}{{ title }}{% if ot %} #{{ ot.id }}{% endif %}{% endblock %}
@@ -11,7 +11,11 @@
 
 {% block breadcrumbs %}
 <div class="breadcrumbs">
-  <a href="{% url 'admin:index' %}">Panel</a>
+  {% if use_admin_base %}
+    <a href="{% url 'admin:index' %}">Panel</a>
+  {% else %}
+    <a href="/">Inicio</a>
+  {% endif %}
   &rsaquo; {{ title }}{% if ot %} #{{ ot.id }}{% endif %}
 </div>
 {% endblock %}
@@ -218,7 +222,13 @@
 
         <div class="submit-row">
           <input type="submit" value="Guardar" class="default">
-          {% if ot %}<a href="{% url 'admin:index' %}" class="button">Panel</a>{% endif %}
+          {% if ot %}
+            {% if use_admin_base %}
+              <a href="{% url 'admin:index' %}" class="button">Panel</a>
+            {% else %}
+              <a href="/" class="button">Inicio</a>
+            {% endif %}
+          {% endif %}
         </div>
       </form>
     </div>

--- a/workorders/views.py
+++ b/workorders/views.py
@@ -198,6 +198,7 @@ def workorder_unified(request, pk=None):
         "title": ("Editar OT" if ot else "Nueva OT"),
         "manual": manual,
         "show_corrective": show_corrective,
+        "use_admin_base": request.path.startswith("/admin/"),
         # Quick-create forms (si existen)
         "qc_vehicle": QuickCreateVehicleForm() if QuickCreateVehicleForm._meta.fields else None,
         "qc_driver": QuickCreateDriverForm() if QuickCreateDriverForm._meta.fields else None,


### PR DESCRIPTION
## Summary
- allow `workorder_unified` view to choose admin or public base template
- adjust workorder form template breadcrumbs and links based on context

## Testing
- `SECRET_KEY=testkey python manage.py test` *(fails: tests module incorrectly imported)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ec8664cc8322acd834add6f000f3