### PR TITLE
Refactor work order form into modular mixins

### DIFF
--- a/workorders/forms.py
+++ b/workorders/forms.py
@@ -4,6 +4,7 @@ from django.forms import inlineformset_factory
 from django.core.exceptions import FieldDoesNotExist
 from django.apps import apps
 from django.urls import reverse_lazy
+from django.conf import settings
 
 from .models import (
     WorkOrder, WorkOrderTask, WorkOrderNote, ProbableCause
@@ -40,9 +41,9 @@ if not SEVERITY_CHOICES:
 if not FAILURE_ORIGIN_CHOICES:
     FAILURE_ORIGIN_CHOICES = [("","---------"), ("MECHANICAL","Mecánica"), ("ELECTRICAL","Eléctrica"), ("OTHER","Otra")]
 
-# ---------- Form principal unificado ----------
-class WorkOrderUnifiedForm(forms.ModelForm):
-    # Conductor y % de responsabilidad (solo si hay modelo Driver)
+# ---------- Mixins para formularios de OT ----------
+
+class DriverFieldsMixin:
     if Driver:
         driver = forms.ModelChoiceField(
             label="Conductor responsable",
@@ -60,57 +61,8 @@ class WorkOrderUnifiedForm(forms.ModelForm):
             required=False, min_value=0, max_value=100
         )
 
-    # Correctivo (UI decide mostrar)
-    pre_diagnosis = forms.CharField(
-        label="Pre-diagnóstico (solo correctivo)",
-        required=False, widget=forms.Textarea(attrs={'rows':3})
-    )
-    failure_origin = forms.ChoiceField(
-        label="Origen de la falla (solo correctivo)",
-        choices=FAILURE_ORIGIN_CHOICES, required=False
-    )
-    severity = forms.ChoiceField(
-        label="Severidad (solo correctivo)",
-        choices=SEVERITY_CHOICES, required=False
-    )
-
-    # Novedades rápidas
-    first_comment = forms.CharField(
-        label="Comentario inicial (opcional)",
-        required=False, widget=forms.Textarea(attrs={'rows':2})
-    )
-    probable_causes = forms.ModelMultipleChoiceField(
-        label="Causas probables (opcional, solo correctivo)",
-        queryset=ProbableCause.objects.all(),
-        required=False,
-        widget=forms.CheckboxSelectMultiple
-    )
-
-    # Campos datetime “reales” si existen en tu modelo
-    dynamic_datetime_fields = ("actual_start", "actual_end", "received_at", "delivered_at", "started_at", "finished_at")
-
-    class Meta:
-        model = WorkOrder
-        fields = [
-            'order_type', 'vehicle', 'description',
-            'status', 'priority',
-            'scheduled_start', 'scheduled_end',
-            'odometer_at_service',
-            # Campos de costo general si tu modelo los trae (se añaden abajo dinámicamente)
-        ]
-        widgets = {
-            'vehicle': forms.Select(
-                attrs={'class': 'select2-ajax', 'data-url': reverse_lazy('vehicle-list')}
-            ),
-            'scheduled_start': forms.DateTimeInput(attrs={'type': 'datetime-local'}),
-            'scheduled_end': forms.DateTimeInput(attrs={'type': 'datetime-local'}),
-            'description': forms.Textarea(attrs={'rows':3}),
-        }
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-
-        # Inicializar conductor existente
         if (
             Driver
             and WorkOrderDriver
@@ -136,37 +88,8 @@ class WorkOrderUnifiedForm(forms.ModelForm):
             except Exception:
                 pass
 
-        # Campos datetime reales si existen
-        for fname in self.dynamic_datetime_fields:
-            if _field_exists(WorkOrder, fname):
-                self.fields[fname] = forms.DateTimeField(
-                    required=False,
-                    widget=forms.DateTimeInput(attrs={'type': 'datetime-local'}),
-                    label=fname.replace("_", " ").capitalize()
-                )
-
-        # Campos de costo general (si existen en tu WorkOrder)
-        for fname in ("is_external", "external_vendor", "external_cost", "service_cost", "total_cost"):
-            if _field_exists(WorkOrder, fname) and fname not in self.fields:
-                self.fields[fname] = forms.CharField(
-                    required=False,
-                    label=fname.replace("_", " ").capitalize()
-                )
-                # Si es bool o decimal, mejoramos el widget:
-                try:
-                    fobj = WorkOrder._meta.get_field(fname)
-                    from django.db import models
-                    if isinstance(fobj, models.BooleanField):
-                        self.fields[fname] = forms.BooleanField(required=False, label=fobj.verbose_name or "¿Externo?")
-                    elif isinstance(fobj, (models.DecimalField, models.FloatField, models.IntegerField)):
-                        self.fields[fname] = forms.DecimalField(required=False, label=fobj.verbose_name or fname.replace("_"," ").capitalize())
-                except Exception:
-                    pass
-
     def save(self, user=None, commit=True):
-        instance = super().save(commit=commit)
-
-        # Conductor / responsabilidad (sólo si existen modelos)
+        instance = super().save(user=user, commit=commit)
         if Driver and WorkOrderDriver and 'driver' in self.cleaned_data:
             driver = self.cleaned_data.get('driver')
             resp = self.cleaned_data.get('driver_responsibility')
@@ -177,23 +100,36 @@ class WorkOrderUnifiedForm(forms.ModelForm):
                 )
             else:
                 WorkOrderDriver.objects.filter(work_order=instance).delete()
+        return instance
 
-        # Comentario inicial -> WorkOrderNote
-        comment = self.cleaned_data.get('first_comment')
-        if comment:
-            note = WorkOrderNote(text=comment, work_order=instance)
-            if _field_exists(WorkOrderNote, "author") and user is not None:
-                setattr(note, "author", user)
-            note.save()
 
+class CorrectiveFieldsMixin:
+    pre_diagnosis = forms.CharField(
+        label="Pre-diagnóstico (solo correctivo)",
+        required=False, widget=forms.Textarea(attrs={'rows':3})
+    )
+    failure_origin = forms.ChoiceField(
+        label="Origen de la falla (solo correctivo)",
+        choices=FAILURE_ORIGIN_CHOICES, required=False
+    )
+    severity = forms.ChoiceField(
+        label="Severidad (solo correctivo)",
+        choices=SEVERITY_CHOICES, required=False
+    )
+    probable_causes = forms.ModelMultipleChoiceField(
+        label="Causas probables (opcional, solo correctivo)",
+        queryset=ProbableCause.objects.all(),
+        required=False,
+        widget=forms.CheckboxSelectMultiple
+    )
+
+    def save(self, user=None, commit=True):
+        instance = super().save(user=user, commit=commit)
         causas = self.cleaned_data.get('probable_causes')
         ot_val = str(self.cleaned_data.get('order_type')).upper()
         ot_is_corrective = ("CORRECTIVE" in ot_val or "CORRECTIV" in ot_val)
         if ot_is_corrective:
             instance.probable_causes.set(causas or [])
-
-        # Guardar campos correctivo si existen en el modelo
-        if ot_is_corrective:
             if _field_exists(WorkOrder, "pre_diagnosis"):
                 instance.pre_diagnosis = self.cleaned_data.get('pre_diagnosis')
             if _field_exists(WorkOrder, "failure_origin"):
@@ -201,17 +137,30 @@ class WorkOrderUnifiedForm(forms.ModelForm):
             if _field_exists(WorkOrder, "severity"):
                 instance.severity = self.cleaned_data.get('severity') or getattr(instance, "severity", None)
             instance.save()
+        return instance
 
-        # Guardar campos datetime reales, si existen
-        touched_dt = False
-        for fname in self.dynamic_datetime_fields:
-            if fname in self.fields:
-                setattr(instance, fname, self.cleaned_data.get(fname))
-                touched_dt = True
-        if touched_dt:
-            instance.save()
 
-        # Guardar campos de costo general si existen
+class CostFieldsMixin:
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for fname in ("is_external", "external_vendor", "external_cost", "service_cost", "total_cost"):
+            if _field_exists(WorkOrder, fname) and fname not in self.fields:
+                self.fields[fname] = forms.CharField(
+                    required=False,
+                    label=fname.replace("_", " ").capitalize()
+                )
+                try:
+                    fobj = WorkOrder._meta.get_field(fname)
+                    from django.db import models
+                    if isinstance(fobj, models.BooleanField):
+                        self.fields[fname] = forms.BooleanField(required=False, label=fobj.verbose_name or "¿Externo?")
+                    elif isinstance(fobj, (models.DecimalField, models.FloatField, models.IntegerField)):
+                        self.fields[fname] = forms.DecimalField(required=False, label=fobj.verbose_name or fname.replace("_", " ").capitalize())
+                except Exception:
+                    pass
+
+    def save(self, user=None, commit=True):
+        instance = super().save(user=user, commit=commit)
         for fname in ("is_external", "external_vendor", "external_cost", "service_cost", "total_cost"):
             if fname in self.fields:
                 val = self.cleaned_data.get(fname)
@@ -219,10 +168,78 @@ class WorkOrderUnifiedForm(forms.ModelForm):
                     setattr(instance, fname, val)
                 except Exception:
                     pass
-        if any(f in self.fields for f in ("is_external","external_vendor","external_cost","service_cost","total_cost")):
+        if any(f in self.fields for f in ("is_external", "external_vendor", "external_cost", "service_cost", "total_cost")):
             instance.save()
-
         return instance
+
+
+# ---------- Form principal unificado ----------
+
+class WorkOrderBaseForm(forms.ModelForm):
+    first_comment = forms.CharField(
+        label="Comentario inicial (opcional)",
+        required=False, widget=forms.Textarea(attrs={'rows':2})
+    )
+
+    dynamic_datetime_fields = ("actual_start", "actual_end", "received_at", "delivered_at", "started_at", "finished_at")
+
+    class Meta:
+        model = WorkOrder
+        fields = [
+            'order_type', 'vehicle', 'description',
+            'status', 'priority',
+            'scheduled_start', 'scheduled_end',
+            'odometer_at_service',
+        ]
+        widgets = {
+            'vehicle': forms.Select(
+                attrs={'class': 'select2-ajax', 'data-url': reverse_lazy('vehicle-list')}
+            ),
+            'scheduled_start': forms.DateTimeInput(attrs={'type': 'datetime-local'}),
+            'scheduled_end': forms.DateTimeInput(attrs={'type': 'datetime-local'}),
+            'description': forms.Textarea(attrs={'rows':3}),
+        }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for fname in self.dynamic_datetime_fields:
+            if _field_exists(WorkOrder, fname):
+                self.fields[fname] = forms.DateTimeField(
+                    required=False,
+                    widget=forms.DateTimeInput(attrs={'type': 'datetime-local'}),
+                    label=fname.replace("_", " ").capitalize()
+                )
+
+    def save(self, user=None, commit=True):
+        instance = super().save(commit=commit)
+        comment = self.cleaned_data.get('first_comment')
+        if comment:
+            note = WorkOrderNote(text=comment, work_order=instance)
+            if _field_exists(WorkOrderNote, "author") and user is not None:
+                setattr(note, "author", user)
+            note.save()
+        touched_dt = False
+        for fname in self.dynamic_datetime_fields:
+            if fname in self.fields:
+                setattr(instance, fname, self.cleaned_data.get(fname))
+                touched_dt = True
+        if touched_dt:
+            instance.save()
+        return instance
+
+
+_mixins = []
+if getattr(settings, 'WORKORDER_ENABLE_DRIVER', True):
+    _mixins.append(DriverFieldsMixin)
+if getattr(settings, 'WORKORDER_ENABLE_CORRECTIVE', True):
+    _mixins.append(CorrectiveFieldsMixin)
+if getattr(settings, 'WORKORDER_ENABLE_COST', True):
+    _mixins.append(CostFieldsMixin)
+_mixins.append(WorkOrderBaseForm)
+
+
+class WorkOrderUnifiedForm(*_mixins):
+    pass
 # ---------- Formset de TAREAS (categoría/subcategoría) ----------
 TaskFormSet = inlineformset_factory(
     WorkOrder, WorkOrderTask,


### PR DESCRIPTION
## Summary
- add DriverFieldsMixin, CorrectiveFieldsMixin, and CostFieldsMixin for modular work order form
- rewrite WorkOrderUnifiedForm to compose mixins and allow enabling via settings

## Testing
- `SECRET_KEY=test python manage.py test` *(fails: ImportError: 'tests' module incorrectly imported from '/workspace/sigma-project/fleet/tests')*

------
https://chatgpt.com/codex/tasks/task_e_68b5f1b0b7488322837f8d135109c935