### PR TITLE
Show non-field errors on order full form

### DIFF
--- a/workorders/templates/workorders/order_full_form.html
+++ b/workorders/templates/workorders/order_full_form.html
@@ -43,6 +43,9 @@
       {% endif %}
 
       <form method="post">
+        {% if form.non_field_errors %}
+        <div class="errornote">{{ form.non_field_errors }}</div>
+        {% endif %}
         {% csrf_token %}
 
       <!-- Datos base -->


### PR DESCRIPTION
## Summary
- display global form errors at the top of the unified work order form using existing error styling

## Testing
- `SECRET_KEY=dummy python manage.py test workorders`


------
https://chatgpt.com/codex/tasks/task_e_68b5f1b494148322b21543ddc1e3586a