### PR TITLE
Fix settings module resolution and admin task config

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -12,9 +12,9 @@ def main():
     # ⬇️ tu SECRET_KEY (la que me diste)
     os.environ.setdefault("SECRET_KEY", "9d29ed5ddd2a0ba5b122b5123cf9a628")
 
-    # ⬇️ NO CAMBIES esta línea: debe apuntar a tu módulo de settings actual.
-    # Si tu manage.py original decía 'sigma.settings' o 'core.settings', mantenlo igual aquí:
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "sigma_project.settings")
+    # Selecciona el módulo de settings según la variable de entorno
+    env = os.environ.get("DJANGO_ENV", "dev")
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", f"project.settings.{env}")
 
     try:
         from django.core.management import execute_from_command_line

--- a/project/asgi.py
+++ b/project/asgi.py
@@ -11,6 +11,8 @@ import os
 
 from django.core.asgi import get_asgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'project.settings')
+# Selecciona el módulo de settings según la variable de entorno
+env = os.environ.get('DJANGO_ENV', 'prod')
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', f'project.settings.{env}')
 
 application = get_asgi_application()

--- a/workorders/admin.py
+++ b/workorders/admin.py
@@ -182,6 +182,6 @@ class MaintenanceManualAdmin(admin.ModelAdmin):
 
 @admin.register(ManualTask)
 class ManualTaskAdmin(admin.ModelAdmin):
-    list_display = ("id", "manual", "category", "subcategory", "km_interval", "months_interval")
+    list_display = ("id", "manual", "km_interval", "description")
     list_filter = ("manual",)
-    search_fields = ("category__name", "subcategory__name")
+    search_fields = ("description",)


### PR DESCRIPTION
## Summary
- align manage.py and ASGI to select settings module via DJANGO_ENV
- remove invalid fields from ManualTaskAdmin

## Testing
- `python manage.py check`
- `python manage.py test` *(fails: ImportError: 'tests' module incorrectly imported from '/workspace/sigma-project/fleet/tests')*

------
https://chatgpt.com/codex/tasks/task_e_68b7082809788322aa5f442bad457dc4